### PR TITLE
💅 Re-add monospaced font for BTC address

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ In 2016, precisely on the September 7th, our [first crowdfunding](https://catars
 At that time, we developed Rosie and made our first joint complaint, with 629 cases reported to the Chamber. Without recurrence, however, we can not continue the work. That is why we have created a space for people who want to contribute frequently, even with minor values, to our project. However we want to go further — if you wanna make us go further:
 
 * Participate in our [recurring crowdfunding campaign on APOIA.se](http://apoia.se/serenata)
-* Donate via Bitcoin: [1Gbvfjmjvur7qwbwNFdPSNDgx66KSdVB5b](https://blockchain.info/address/1Gbvfjmjvur7qwbwNFdPSNDgx66KSdVB5b)
+* Donate via Bitcoin: [`1Gbvfjmjvur7qwbwNFdPSNDgx66KSdVB5b`](https://blockchain.info/address/1Gbvfjmjvur7qwbwNFdPSNDgx66KSdVB5b)
 
 ## License
 


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

Totally _nail care_ based probably on my OCD, but I think visually speaking it's a nice thing to use mono-spaced font for the BTC address: it clearly separates the arguably random string from the rest of the text and avoid confusing `O` with `0` in an important string ; )

**What was done to achieve this purpose?**

Added the proper markers to show the BTC address with mono-spaced font in MarkDown renders.

**How to test if it really works?**

Just check [the visual version of the `README.md` in this PR](https://github.com/okfn-brasil/serenata-de-amor/blob/3ead79ed992d8264a50f73a11f36e23d6823d2fe/README.md).


**Who are the best people to help reviews it?**

@anaschwendler 