### PR TITLE
Fix Rosie instalation via Docker Compose

### DIFF
--- a/rosie/setup
+++ b/rosie/setup
@@ -4,6 +4,6 @@ import pip
 from shutil import copyfile
 
 
-copyfile('rosie/config.ini.example', 'rosie/config.ini')
+copyfile('config.ini.example', 'config.ini')
 
-pip.main(['install', '--upgrade', '-r', 'rosie/requirements.txt'])
+pip.main(['install', '--upgrade', '-r', 'requirements.txt'])


### PR DESCRIPTION
Not sure why we added the directory `rosie/` to the `setup` script. I
tried it today and it didn't work – removing it, it works. Can anyone else test it please?