### PR TITLE
Update New Relic Python package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ django-test-without-migrations==0.6
 djangorestframework==3.7.7
 freezegun==0.3.9
 gunicorn==19.7.1
-newrelic==2.104.0.86
+newrelic==2.106.1.88
 psycopg2==2.7.4
 py-gfm==0.1.3
 python-decouple==3.1


### PR DESCRIPTION
Other PRs are failing because the version we're currently using is
marked as unsafe by pyup.io. This PR brings New Relic package to it's
latest version.