### PR TITLE
Unpin serenata-toolbox

### DIFF
--- a/research/requirements.txt
+++ b/research/requirements.txt
@@ -8,5 +8,5 @@ numpy==1.14.2
 pandas==0.22.0
 python-decouple==3.1
 requests==2.18.4
-serenata-toolbox==15.0.0
+serenata-toolbox  # pyup: ignore
 tqdm==4.19.9

--- a/rosie/requirements.txt
+++ b/rosie/requirements.txt
@@ -4,4 +4,4 @@ numpy==1.14.2
 # scipy must come before scikit-learn in order to build the wheel in docker image
 scipy==1.0.1
 scikit-learn==0.19.1
-serenata-toolbox==15.0.0
+serenata-toolbox  # pyup: ignore


### PR DESCRIPTION
@Irio, @anaschwendler: what do you think about unpinning `serenata-toolbox` from pyup.io so it always uses the latest version of the toolbox?