### PR TITLE
django 2 update: making string safe to show

### DIFF
--- a/jarbas/dashboard/admin.py
+++ b/jarbas/dashboard/admin.py
@@ -6,6 +6,7 @@ from django.contrib.admin import SimpleListFilter
 from django.contrib.postgres.search import SearchQuery, SearchRank
 from django.db.models import F
 from django.forms.widgets import Widget
+from django.utils.safestring import mark_safe
 
 from jarbas.chamber_of_deputies.models import Reimbursement
 from jarbas.public_admin.admin import PublicAdminModelAdmin
@@ -294,37 +295,33 @@ class ReimbursementModelAdmin(PublicAdminModelAdmin):
             return obj.cnpj_cpf
 
     def supplier_info(self, obj):
-        return '{}<br>{}'.format(obj.supplier, self._format_document(obj))
+        return mark_safe('{}<br>{}'.format(obj.supplier, self._format_document(obj)))
 
     supplier_info.short_description = 'Fornecedor'
-    supplier_info.allow_tags = True
 
     def jarbas(self, obj):
         base_url = '/layers/#/documentId/{}/'
         url = base_url.format(obj.document_id)
         image_src = '/static/favicon/favicon-16x16.png'
         image = '<img alt="Ver no Jarbas" src="{}">'.format(image_src)
-        return '<a href="{}">{}</a>'.format(url, image)
+        return mark_safe('<a href="{}">{}</a>'.format(url, image))
 
     jarbas.short_description = ''
-    jarbas.allow_tags = True
 
     def rosies_tweet(self, obj):
         try:
-            return '<a href="{}">🤖</a>'.format(obj.tweet.get_url())
+            return mark_safe('<a href="{}">🤖</a>'.format(obj.tweet.get_url()))
         except Reimbursement.tweet.RelatedObjectDoesNotExist:
             return ''
 
     rosies_tweet.short_description = ''
-    rosies_tweet.allow_tags = True
 
     def receipt_link(self, obj):
         if not obj.receipt_url:
             return ''
-        return '<a target="_blank" href="{}">📃</a>'.format(obj.receipt_url)
+        return mark_safe('<a target="_blank" href="{}">📃</a>'.format(obj.receipt_url))
 
     receipt_link.short_description = ''
-    receipt_link.allow_tags = True
 
     def suspicious(self, obj):
         return obj.suspicions is not None


### PR DESCRIPTION

**Making safe to show object proprieties**

Jarbas was showing strings with html tags that are not rendered

**How to test if it really works?**
Run `docker-compose up django` and access `localhost:8000`. The first info should be a readable name


Was 

![screenshot from 2018-04-17 20-00-01](https://user-images.githubusercontent.com/182472/38887755-faef1258-4279-11e8-8306-6df68708675a.png)


Now

![photo_2018-04-17_19-31-34](https://user-images.githubusercontent.com/182472/38887766-02a53090-427a-11e8-8743-aa9da564b657.jpg)

