### PR TITLE
Optimize query in the dashboard

### DIFF
--- a/jarbas/dashboard/admin.py
+++ b/jarbas/dashboard/admin.py
@@ -283,6 +283,7 @@ class ReimbursementModelAdmin(PublicAdminModelAdmin):
 
     fields = tuple(f.name for f in ALL_FIELDS)
     readonly_fields = tuple(READONLY_FIELDS)
+    list_select_related = ('tweet',)
 
     def _format_document(self, obj):
         if obj.cnpj_cpf:


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

I noticed the home of the reimbursements in the dashboard required **105** queries in order to load the reimbursement list. That was ludicrous.

**What was done to achieve this purpose?**

I used the `list_select_related` and reduced the queries from 105 to only 5. This means more speed and less overload in our database.

**How to test if it really works?**

Open the dashboard and check if all expected info is still there ; )

**Who can help reviewing it?**

@anaschwendler @Irio @jtemporal @cabral 