### PR TITLE
Correct Tech Crash Course link on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # [![Operação Serenata de Amor](docs/logo.png)](https://serenata.ai/en)
 
 1. [**Non-tech** crash course into Operação Serenata de Amor](#non-tech-crash-course-into-operação-serenata-de-amor)
-2. [**Tech** crash course into Operação Serenata de Amor](#non-tech-crash-course-into-operação-serenata-de-amor)
+2. [**Tech** crash course into Operação Serenata de Amor](#tech-crash-course-into-operação-serenata-de-amor)
 3. [Contributing with code and tech skills](#contributing-with-code-and-tech-skills)
 4. [Supporting](#supporting)
 5. [Acknowledgments](#acknowledgments)


### PR DESCRIPTION
This fixes incorrect link on `README.md`.

It also creates a newline at the end of the file, I didn't add it manually and edited the file using te GitHub interface to make sure it was not a configuration of my text editor doing that.
