### PR TITLE
Minor fixes and enhancements on envvars & settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
     - AMAZON_BUCKET=serenata-de-amor-data
     - AMAZON_REGION=sa-east-1
     - DATABASE_URL=postgres://postgres@localhost/jarbas
+    - CACHE_BACKEND=django.core.cache.backends.dummy.DummyCache
 
 install:
   - cp contrib/.env.sample .env

--- a/contrib/.env.sample
+++ b/contrib/.env.sample
@@ -1,15 +1,16 @@
 ALLOWED_HOSTS=*
 DEBUG=True
 HTTPS_METHOD=redirect
-INBOX_PASSWORD=
-LETSENCRYPT_EMAIL=contato@serenata.ai
-POSTGRES_PASSWORD=mysecretpassword
-POSTGRES_USER=jarbas
 SECRET_KEY=my-secret
 USE_X_FORWARDED_HOST=False
 CACHE_BACKEND=django.core.cache.backends.memcached.MemcachedCache
+
 VIRTUAL_HOST=jarbas.serenata.ai
 VIRTUAL_PROTO=http
+LETSENCRYPT_EMAIL=contato@serenata.ai
+
+POSTGRES_PASSWORD=mysecretpassword
+POSTGRES_USER=jarbas
 POSTGRES_DB=jarbas
 
 DATABASE_URL=postgres://jarbas:mysecretpassword@postgres/jarbas
@@ -43,3 +44,5 @@ YELP_ACCESS_TOKEN=
 NEW_RELIC_DEVELOPER_MODE=true
 NEW_RELIC_ENVIRONMENT=development
 NEW_RELIC_LICENSE_KEY=
+
+INBOX_PASSWORD=

--- a/contrib/.env.sample
+++ b/contrib/.env.sample
@@ -6,11 +6,15 @@ LETSENCRYPT_EMAIL=contato@serenata.ai
 POSTGRES_PASSWORD=mysecretpassword
 POSTGRES_USER=jarbas
 SECRET_KEY=my-secret
+USE_X_FORWARDED_HOST=False
+CACHE_BACKEND=django.core.cache.backends.memcached.MemcachedCache
 VIRTUAL_HOST=jarbas.serenata.ai
 VIRTUAL_PROTO=http
+POSTGRES_DB=jarbas
 
 DATABASE_URL=postgres://jarbas:mysecretpassword@postgres/jarbas
 CELERY_BROKER_URL=amqp://guest:guest@queue/
+CACHE_LOCATION=localhost:11211
 LOGGING_URL=
 
 AMAZON_ACCESS_KEY=

--- a/jarbas/chamber_of_deputies/tests/test_reimbursement_view.py
+++ b/jarbas/chamber_of_deputies/tests/test_reimbursement_view.py
@@ -113,12 +113,15 @@ class TestRetrieveApi(TestCase):
     def test_contents_with_tweet(self):
         status = random_tweet_status()
         mixer.blend(Tweet, reimbursement=self.reimbursement, status=status)
-        expected = self.sample_response
+        expected = self.sample_response.copy()
         expected['rosies_tweet'] = self.reimbursement.tweet.get_url()
-        url = resolve_url('chamber_of_deputies:reimbursement-detail',
-                          document_id=self.reimbursement.document_id)
+        url = resolve_url(
+            'chamber_of_deputies:reimbursement-detail',
+            document_id=self.reimbursement.document_id
+        )
         resp = self.client.get(url)
         contents = loads(resp.content.decode('utf-8'))
+        self.assertTrue(contents['rosies_tweet'].endswith(str(status)), f'{status} not found')
         self.assertEqual(expected, contents)
 
     def test_contents_with_receipt_text(self):

--- a/jarbas/settings.py
+++ b/jarbas/settings.py
@@ -70,7 +70,7 @@ MIDDLEWARE = [
 ]
 
 if not DEBUG:
-	MIDDLEWARE.insert(2, 'whitenoise.middleware.WhiteNoiseMiddleware')
+    MIDDLEWARE.insert(2, 'whitenoise.middleware.WhiteNoiseMiddleware')
 
 ROOT_URLCONF = 'jarbas.urls'
 

--- a/jarbas/settings.py
+++ b/jarbas/settings.py
@@ -11,6 +11,8 @@ https://docs.djangoproject.com/en/1.10/ref/settings/
 """
 
 import os
+import re
+import socket
 
 from decouple import Csv, config
 from dj_database_url import parse
@@ -191,6 +193,12 @@ CACHES = {
     }
 }
 
+
+# Django Debug Toolbar
+# Set internal IP dinamycally
+
+INTERNAL_IP = socket.gethostbyname(socket.gethostname())
+INTERNAL_IPS = (re.sub(r'\d$', '1', INTERNAL_IP),)
 
 # Queue
 


### PR DESCRIPTION
Replaces #361 that was accidently merged.

---
**What is the purpose of this Pull Request?**
While working on #360 I found minor room for improvements, the commits are self-explanatory (feel free to squash them on merge).

**What was done ~~to achieve this purpose~~?**

* I've found some vars missing from the sample `.env` so I added them (1e6688f)
* I found the first-block of the sample `.env` too big to and re-sorted it (ca61fec)
* While exploring some performance issues for (#360) I missed the Django Debug Tool bar, so I configured it properly for Docker environments using a dynamic `INTERNAL_IPS` alternative (9f4d738)
* The linter has pointed out a tab invading our `settings.py` and I squashed it using 4 spaces instead (5b518e5)
* I've noted that a certain test was (unecessarily) chainging an instance variable, so I opted to use a copy of this variable instead (32cc098)

**How to test if it really works?**

I would recommend three simple things:

1. If there's no typo or any absurdity in a commit-per-commit review, we're probably good to go
2. If `docker-compose up` still bringing the project to life I've probably not broken anything
3. Finally, in Travis CI we trust.

**Who can help reviewing it?**
@anaschwendler @cabral @Irio @jtemporal 