### PR TITLE
Add progress bar to search vector command

### DIFF
--- a/jarbas/chamber_of_deputies/management/commands/searchvector.py
+++ b/jarbas/chamber_of_deputies/management/commands/searchvector.py
@@ -1,15 +1,39 @@
 from django.core.management.base import BaseCommand
 from django.contrib.postgres.search import SearchVector
 
+from tqdm import tqdm
+
 from jarbas.chamber_of_deputies.models import Reimbursement
 
 
 class Command(BaseCommand):
 
+    BATCH_SIZE = 4096
+
+    def add_arguments(self, parser):
+        parser.add_argument('--silent', dest='silent', action='store_true')
+        parser.add_argument(
+            '--all', action='store_true',
+            dest='all_reimbursements',
+            help='Re-create all search vectors'
+        )
+        parser.add_argument(
+            '--batch-size', '-b', dest='batch_size', type=int,
+            default=self.BATCH_SIZE,
+            help='Batch size for bulk update (default: 4096)'
+        )
+
     def handle(self, *args, **options):
-        total = Reimbursement.objects.count()
-        print('Creating search vector for {} reimbursements…'.format(total))
-        print('This takes several minutes/hours.')
+        batch_size = options.get('batch_size', self.BATCH_SIZE)
+        silent = options.get('silent')
+        all_reimbursements = options.get('all_reimbursements')
+
+        queryset = Reimbursement.objects.filter(search_vector=None)
+        if all_reimbursements:
+            queryset = Reimbursement.objects.all()
+
+        if not queryset.exists():
+            return
 
         search_vector = \
             SearchVector('congressperson_name', config='portuguese', weight='A') + \
@@ -23,4 +47,22 @@ class Command(BaseCommand):
             SearchVector('subquota_description', config='portuguese', weight='D') + \
             SearchVector('subquota_group_description', config='portuguese', weight='D')
 
-        Reimbursement.objects.update(search_vector=search_vector)
+        pks = tuple(obj['pk'] for obj in queryset.values('pk'))
+        total = len(pks)
+
+        if not silent:
+            print(f'Creating search vector for {total} reimbursements…')
+
+        kwargs = {
+            'total': total,
+            'desc': 'Reimbursements',
+            'unit': 'vector',
+            'disable': silent
+        }
+        with tqdm(**kwargs) as progress_bar:
+            for start in range(0, total, batch_size):
+                end = min(start + batch_size, total)
+                Reimbursement.objects \
+                    .filter(pk__in=pks[start:end]) \
+                    .update(search_vector=search_vector)
+                progress_bar.update(end - start)

--- a/jarbas/chamber_of_deputies/tests/test_reimbursement_view.py
+++ b/jarbas/chamber_of_deputies/tests/test_reimbursement_view.py
@@ -25,13 +25,6 @@ def get_reimbursement(**kwargs):
     return mixer.cycle(quantity).blend(Reimbursement, search_vector=None, **kwargs)
 
 
-def create_search_vector():
-    """ Running the command silently """
-    out = StringIO()
-    sys.stdout = out
-    call_command('searchvector', stdout=out)
-
-
 class TestListApi(TestCase):
 
     def setUp(self):
@@ -130,8 +123,7 @@ class TestListApi(TestCase):
         get_reimbursement(congressperson_name='FULANO SILVA BELTRANO', applicant_id=221)
         get_reimbursement(congressperson_name='SILVA TESTA NOME', applicant_id=23)
         get_reimbursement(congressperson_name='BELTRANO CHAVES', applicant_id=23)
-
-        create_search_vector()
+        call_command('searchvector', silent=True)
 
         search_data = (
             ('search', 'Silva'),
@@ -146,8 +138,7 @@ class TestListApi(TestCase):
         get_reimbursement(congressperson_name='FULANO SILVA BELTRANO', applicant_id=221)
         get_reimbursement(supplier='PRESTADORA SILVA', applicant_id=23)
         get_reimbursement(congressperson_name='BELTRANO CHAVES', applicant_id=23)
-
-        create_search_vector()
+        call_command('searchvector', silent=True)
 
         search_data = (
             ('search', 'Silva'),

--- a/jarbas/chamber_of_deputies/tests/test_searchvector_command.py
+++ b/jarbas/chamber_of_deputies/tests/test_searchvector_command.py
@@ -1,6 +1,5 @@
-from unittest.mock import patch
-
 from django.test import TestCase
+from mixer.backend.django import mixer
 
 from jarbas.chamber_of_deputies.management.commands.searchvector import Command
 from jarbas.chamber_of_deputies.models import Reimbursement
@@ -8,10 +7,10 @@ from jarbas.chamber_of_deputies.models import Reimbursement
 
 class TestCommandHandler(TestCase):
 
-    @patch.object(Reimbursement.objects, 'update')
-    @patch('jarbas.chamber_of_deputies.management.commands.searchvector.print')
-    def test_handler(self, print_, update):
+    def test_handler(self):
+        mixer.cycle(3).blend(Reimbursement, search_vector=None)
         command = Command()
-        command.handle()
-        self.assertEqual(2, print_.call_count)
-        self.assertEqual(1, update.call_count)
+        command.handle(batch_size=2, silent=True)
+
+        queryset = Reimbursement.objects.exclude(search_vector=None)
+        self.assertEqual(3, queryset.count())

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,5 @@ python-twitter==3.4.1
 reprint==0.3.0 # pyup: ignore
 requests==2.18.4
 rows==0.3.1
+tqdm==4.23.1
 whitenoise==3.3.1


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

The `searchvector` Jarbas command took too long and offered now progress feedback to the user. Also it was quite heavy on the database.

**What was done to achieve this purpose?**

* Update in batches/slices to be more friendly to the database server
* Use `tqdm` to show the progress based on these batches, to be more friendly with the user

**How to test if it really works?**

Just [run the `searchvector` command](https://github.com/okfn-brasil/serenata-de-amor/tree/master/jarbas#creating-search-vector). As we need a new dependency (`tqdm`) pip-installed you might need to change your `docker-compose.yml` locally:

```diff
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,9 @@ services:
       - ./rosie:/code
 
   django:
-    image: serenata/django
+    # image: serenata/django
+    build:
+      context: .
     depends_on:
       - elm
       - postgres
```