### PR TITLE
Optimize Jarbas Dashboard using cache

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - elm
       - postgres
       - tasks
+      - cache
     environment:
       - NEW_RELIC_APP_NAME=Jarbas (Django); Jarbas (Combined)
     env_file:
@@ -64,3 +65,6 @@ services:
     volumes:
       - ./research:/mnt/code
     hostname: research
+
+  cache:
+    image: memcached:1.5.8-alpine

--- a/jarbas/dashboard/admin/__init__.py
+++ b/jarbas/dashboard/admin/__init__.py
@@ -359,7 +359,7 @@ class ReimbursementModelAdmin(PublicAdminModelAdmin):
             return obj.cnpj_cpf
 
     def supplier_info(self, obj):
-        return mark_safe('{}<br>{}'.format(obj.supplier, self._format_document(obj)))
+        return mark_safe(f'{obj.suplier}<br>{self._format_document(obj)}')
 
     supplier_info.short_description = 'Fornecedor'
 
@@ -383,7 +383,7 @@ class ReimbursementModelAdmin(PublicAdminModelAdmin):
     def receipt_link(self, obj):
         if not obj.receipt_url:
             return ''
-        return mark_safe('<a target="_blank" href="{}">📃</a>'.format(obj.receipt_url))
+        return mark_safe(f'<a target="_blank" href="{obj.receipt_url}">📃</a>')
 
     receipt_link.short_description = ''
 

--- a/jarbas/dashboard/admin/list_filters.py
+++ b/jarbas/dashboard/admin/list_filters.py
@@ -1,0 +1,143 @@
+from django.core.cache import cache
+from django.contrib.admin import SimpleListFilter
+
+from jarbas.chamber_of_deputies.models import Reimbursement
+from jarbas.dashboard.admin.subquotas import Subquotas
+
+
+class CachedListFilter(SimpleListFilter):
+
+    timeout = 60 * 60 * 6  # 6h
+
+    def lookups(self, request, model_admin):
+        cached = cache.get(self.cache_key)
+        if cached:
+            return cached
+
+        queryset = Reimbursement.objects.distinct(self.parameter_name) \
+            .order_by(self.parameter_name) \
+            .values_list(self.parameter_name, self.parameter_name)
+
+        value = tuple(state for state in queryset if all(state))
+        cache.set(self.cache_key, value, self.timeout)
+        return value
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if not value:
+            return queryset
+
+        kwarg = {self.parameter_name: value}
+        return queryset.filter(**kwarg)
+
+
+class JarbasListFilter(SimpleListFilter):
+
+    options = tuple()
+
+    def lookups(self, request, model_admin):
+        return self.options
+
+    def queryset(self, request, queryset):
+        if not self.value():
+            return queryset
+
+        kwarg = {self.parameter_name: self.value()}
+        return queryset.filter(**kwarg)
+
+
+class SuspiciousListFilter(JarbasListFilter):
+
+    title = 'reembolso suspeito'
+    parameter_name = 'is_suspicions'
+    options = (
+        ('yes', 'Sim'),
+        ('no', 'Não'),
+    )
+
+    def queryset(self, request, queryset):
+        filter_option = {
+            'yes': queryset.suspicions(True),
+            'no': queryset.suspicions(False)
+        }
+        return filter_option.get(self.value(), queryset)
+
+
+class HasReceiptFilter(JarbasListFilter):
+
+    title = 'nota fiscal digitalizada'
+    parameter_name = 'has_receipt'
+    options = (
+        ('yes', 'Sim'),
+        ('no', 'Não'),
+    )
+
+    def queryset(self, request, queryset):
+        receipt_url_filter = {
+            'yes': queryset.has_receipt_url(True),
+            'no': queryset.has_receipt_url(False)
+        }
+        return receipt_url_filter.get(self.value(), queryset)
+
+
+class MonthListFilter(JarbasListFilter):
+
+    title = 'mês'
+    parameter_name = 'month'
+    options = (
+        (1, 'Janeiro'),
+        (2, 'Fevereiro'),
+        (3, 'Março'),
+        (4, 'Abril'),
+        (5, 'Maio'),
+        (6, 'Junho'),
+        (7, 'Julho'),
+        (8, 'Agosto'),
+        (9, 'Setembro'),
+        (10, 'Outubro'),
+        (11, 'Novembro'),
+        (12, 'Dezembro')
+    )
+
+
+class DocumentTypeListFilter(JarbasListFilter):
+
+    title = 'tipo do documento fiscal'
+    parameter_name = 'document_type'
+    options = (
+        (0, 'Nota fiscal'),
+        (1, 'Recibo simples'),
+        (2, 'Despesa no exterior')
+    )
+
+
+class SubquotaListFilter(SimpleListFilter, Subquotas):
+
+    title = 'subcota'
+    parameter_name = 'subquota_id'
+    default_value = None
+
+    def lookups(self, request, model_admin):
+        return self.OPTIONS
+
+    def queryset(self, request, queryset):
+        subquota = dict(self.OPTIONS).get(self.value())
+        if not subquota:
+            return queryset
+        return queryset.filter(subquota_description=self.en_us(subquota))
+
+
+class StateListFilter(CachedListFilter):
+
+    title = 'estado'
+    parameter_name = 'state'
+    default_value = None
+    cache_key = 'dashboard_state_list_filter_lookups'
+
+
+class YearListFilter(CachedListFilter):
+
+    title = 'ano'
+    parameter_name = 'year'
+    default_value = None
+    cache_key = 'dashboard_year_list_filter_lookups'

--- a/jarbas/dashboard/admin/paginators.py
+++ b/jarbas/dashboard/admin/paginators.py
@@ -1,0 +1,21 @@
+from hashlib import md5
+
+from django.core.cache import cache
+from django.core.paginator import Paginator
+
+
+class CachedCountPaginator(Paginator):
+    """Cached the paginator count (for performance)"""
+
+    @property
+    def count(self):
+        query = self.object_list.query.__str__()
+        hashed = md5(query.encode('utf-8')).hexdigest()
+        key = f'dashboard_count_{hashed}'
+        count = cache.get(key)
+
+        if count is None:
+            count = super(CachedCountPaginator, self).count
+            cache.set(key, count, 60 * 60 * 6)
+
+        return count

--- a/jarbas/dashboard/admin/subquotas.py
+++ b/jarbas/dashboard/admin/subquotas.py
@@ -1,0 +1,89 @@
+class Subquotas:
+
+    EN_US = (
+        'Maintenance of office supporting parliamentary activity',
+        'Locomotion, meal and lodging',
+        'Fuels and lubricants',
+        'Consultancy, research and technical work',
+        'Publicity of parliamentary activity',
+        'Purchase of office supplies',
+        'Software purchase or renting; Postal services; Subscriptions',
+        'Security service provided by specialized company',
+        'Flight tickets',
+        'Telecommunication',
+        'Postal services',
+        'Publication subscriptions',
+        'Congressperson meal',
+        'Lodging, except for congressperson from Distrito Federal',
+        'Automotive vehicle renting or watercraft charter',
+        'Aircraft renting or charter of aircraft',
+        'Automotive vehicle renting or charter',
+        'Watercraft renting or charter',
+        'Taxi, toll and parking',
+        'Terrestrial, maritime and fluvial tickets',
+        'Participation in course, talk or similar event',
+        'Flight ticket issue'
+    )
+
+    PT_BR = (
+        'Manutenção de escritório de apoio à atividade parlamentar',
+        'Locomoção, alimentação e  hospedagem',
+        'Combustíveis e lubrificantes',
+        'Consultorias, pesquisas e trabalhos técnicos',
+        'Divulgação da atividade parlamentar',
+        'Aquisição de material de escritório',
+        'Aquisição ou loc. de software serv. postais ass.',
+        'Serviço de segurança prestado por empresa especializada',
+        'Passagens aéreas',
+        'Telefonia',
+        'Serviços postais',
+        'Assinatura de publicações',
+        'Fornecimento de alimentação do parlamentar',
+        'Hospedagem ,exceto do parlamentar no distrito federal',
+        'Locação de veículos automotores ou fretamento de embarcações',
+        'Locação ou fretamento de aeronaves',
+        'Locação ou fretamento de veículos automotores',
+        'Locação ou fretamento de embarcações',
+        'Serviço de táxi, pedágio e estacionamento',
+        'Passagens terrestres, marítimas ou fluviais',
+        'Participação em curso, palestra ou evento similar',
+        'Emissão bilhete aéreo'
+    )
+
+    NUMBERS = (
+        '1',
+        '2',
+        '3',
+        '4',
+        '5',
+        '6',
+        '7',
+        '8',
+        '9',
+        '10',
+        '11',
+        '12',
+        '13',
+        '14',
+        '15',
+        '119',
+        '120',
+        '121',
+        '122',
+        '123',
+        '137',
+        '999'
+    )
+
+    OPTIONS = sorted(zip(NUMBERS, PT_BR), key=lambda t: t[1])
+
+    PT_BR_TRANSLATIONS = dict(zip(EN_US, PT_BR))
+    EN_US_TRANSLATIONS = dict(zip(PT_BR, EN_US))
+
+    @classmethod
+    def pt_br(cls, en_us):
+        return cls.PT_BR_TRANSLATIONS.get(en_us)
+
+    @classmethod
+    def en_us(cls, pt_br):
+        return cls.EN_US_TRANSLATIONS.get(pt_br)

--- a/jarbas/dashboard/admin/widgets.py
+++ b/jarbas/dashboard/admin/widgets.py
@@ -1,0 +1,54 @@
+import json
+
+from django.forms.widgets import Widget
+
+from jarbas.dashboard.admin.subquotas import Subquotas
+
+
+class ReceiptUrlWidget(Widget):
+
+    def render(self, name, value, attrs=None, renderer=None):
+        if not value:
+            return ''
+
+        url = '<div class="readonly"><a href="{}" target="_blank">{}</a></div>'
+        return url.format(value, value)
+
+
+class SubquotaWidget(Widget, Subquotas):
+
+    def render(self, name, value, attrs=None, renderer=None):
+        value = self.pt_br(value) or value
+        return '<div class="readonly">{}</div>'.format(value)
+
+
+class SuspiciousWidget(Widget):
+
+    SUSPICIONS = (
+        'meal_price_outlier',
+        'over_monthly_subquota_limit',
+        'suspicious_traveled_speed_day',
+        'invalid_cnpj_cpf',
+        'election_expenses',
+        'irregular_companies_classifier'
+    )
+
+    HUMAN_NAMES = (
+        'Preço de refeição muito incomum',
+        'Extrapolou limita da (sub)quota',
+        'Muitas despesas em diferentes cidades no mesmo dia',
+        'CPF ou CNPJ inválidos',
+        'Gasto com campanha eleitoral',
+        'CNPJ irregular'
+    )
+
+    MAP = dict(zip(SUSPICIONS, HUMAN_NAMES))
+
+    def render(self, name, value, attrs=None, renderer=None):
+        value_as_dict = json.loads(value)
+        if not value_as_dict:
+            return ''
+
+        values = (self.MAP.get(k, k) for k in value_as_dict.keys())
+        suspicions = '<br>'.join(values)
+        return '<div class="readonly">{}</div>'.format(suspicions)

--- a/jarbas/dashboard/tests/test_dashboard_admin.py
+++ b/jarbas/dashboard/tests/test_dashboard_admin.py
@@ -4,13 +4,9 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase
 
 from jarbas.chamber_of_deputies.models import Reimbursement
-from jarbas.dashboard.admin import (
-    ReceiptUrlWidget,
-    ReimbursementModelAdmin,
-    SubquotaWidget,
-    SubquotaListFilter,
-    SuspiciousWidget,
-)
+from jarbas.dashboard.admin import ReimbursementModelAdmin
+from jarbas.dashboard.admin.list_filters import SubquotaListFilter
+from jarbas.dashboard.admin.widgets import ReceiptUrlWidget, SubquotaWidget, SuspiciousWidget
 
 
 Request = namedtuple('Request', ('method',))


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

Jarbas Dashboard is still extremely slow and now I attempt to use cache in order to make it faster.

**What was done to achieve this purpose?**

* Cache Django Admin `COUNT` queries
* Cache `DISTINCT` queries used to build Django Admin filters such as state and year

**How to test if it really works?**

Spin up the services and browser [the dashbaord](http://0.0.0.0:8000/dashboard/chamber_of_deputies/reimbursement/) to check I haven't broken anything. If you have the Django Toolbar enabled you can check cache is working playing around with `CACHE_BACKEND` envvar.

**TODO**

We need to make sure the cache is working on production servers. I noticed it was removed from the `docker-compose.yml`, so I'm not sure if it's in our private `docker-cloud.yml`. As Docker changed its interface (there's no toggle for _Sawrm mode_ anymore) I'm still struggling to check our production stack (cc @Irio).

**Thanks**

@fcevado who helped me identify some bottlenecks 👍 