### PR TITLE
Bugfix and enhancements on coercing dates stage

### DIFF
--- a/rosie/rosie/chamber_of_deputies/adapter.py
+++ b/rosie/rosie/chamber_of_deputies/adapter.py
@@ -112,6 +112,6 @@ class Adapter:
         df['is_party_expense'] = df['congressperson_id'].isnull()
 
     def coerce_dates(self, df):
-        for field in ('issue_date', 'situation_date'):
+        for field, fmt in (('issue_date', None), ('situation_date', '%d/%m/%Y')):
             self.log.info(f'Coercing `{field}` fields to date data type')
-            df[field] = pd.to_datetime(df[field], errors='coerce')
+            df[field] = pd.to_datetime(df[field], format=fmt, errors='coerce')

--- a/rosie/rosie/chamber_of_deputies/adapter.py
+++ b/rosie/rosie/chamber_of_deputies/adapter.py
@@ -112,6 +112,6 @@ class Adapter:
         df['is_party_expense'] = df['congressperson_id'].isnull()
 
     def coerce_dates(self, df):
-        for field, fmt in (('issue_date', None), ('situation_date', '%d/%m/%Y')):
+        for field, fmt in (('issue_date', '%Y-%m-%d'), ('situation_date', '%d/%m/%Y')):
             self.log.info(f'Coercing `{field}` fields to date data type')
             df[field] = pd.to_datetime(df[field], format=fmt, errors='coerce')

--- a/rosie/rosie/chamber_of_deputies/tests/test_adapter.py
+++ b/rosie/rosie/chamber_of_deputies/tests/test_adapter.py
@@ -8,6 +8,7 @@ import pandas as pd
 from freezegun import freeze_time
 
 from rosie.chamber_of_deputies.adapter import Adapter
+from datetime import date
 
 
 FIXTURES = Path() / 'rosie' / 'chamber_of_deputies' / 'tests' / 'fixtures'
@@ -88,4 +89,5 @@ class TestAdapter(TestCase):
     def test_coerce_situation_date(self, reimbursements, fetch):
         adapter = Adapter(self.temp_path)
         df = adapter.dataset
-        self.assertTrue(any(dt.month == 9 and dt.day == 6 for dt in df['situation_date']))
+        self.assertIn(date(2011,9,6), [ts.date() for ts in df.situation_date])
+

--- a/rosie/rosie/chamber_of_deputies/tests/test_adapter.py
+++ b/rosie/rosie/chamber_of_deputies/tests/test_adapter.py
@@ -1,4 +1,5 @@
 import shutil
+from datetime import date
 from pathlib import Path
 from tempfile import mkdtemp
 from unittest import TestCase
@@ -8,7 +9,6 @@ import pandas as pd
 from freezegun import freeze_time
 
 from rosie.chamber_of_deputies.adapter import Adapter
-from datetime import date
 
 
 FIXTURES = Path() / 'rosie' / 'chamber_of_deputies' / 'tests' / 'fixtures'

--- a/rosie/rosie/chamber_of_deputies/tests/test_adapter.py
+++ b/rosie/rosie/chamber_of_deputies/tests/test_adapter.py
@@ -82,3 +82,11 @@ class TestAdapter(TestCase):
             call()()
         ))
         fetch.assert_called_once_with(Adapter.COMPANIES_DATASET, self.temp_path)
+
+    @freeze_time('2010-11-12')
+    @patch('rosie.chamber_of_deputies.adapter.fetch')
+    @patch('rosie.chamber_of_deputies.adapter.Reimbursements')
+    def test_coerce_situation_date(self, reimbursements, fetch):
+        adapter = Adapter(self.temp_path)
+        df = adapter.dataset
+        self.assertTrue(any(dt.month == 9 and dt.day == 6 for dt in df['situation_date']))

--- a/rosie/rosie/chamber_of_deputies/tests/test_adapter.py
+++ b/rosie/rosie/chamber_of_deputies/tests/test_adapter.py
@@ -86,8 +86,8 @@ class TestAdapter(TestCase):
 
     @patch('rosie.chamber_of_deputies.adapter.fetch')
     @patch('rosie.chamber_of_deputies.adapter.Reimbursements')
-    def test_coerce_situation_date(self, reimbursements, fetch):
+    def test_coerce_dates(self, reimbursements, fetch):
         adapter = Adapter(self.temp_path)
         df = adapter.dataset
-        self.assertIn(date(2011,9,6), [ts.date() for ts in df.situation_date])
-
+        self.assertIn(date(2011, 9, 6), [ts.date() for ts in df.situation_date])
+        self.assertIn(date(2009, 6, 1), [ts.date() for ts in df.issue_date])

--- a/rosie/rosie/chamber_of_deputies/tests/test_adapter.py
+++ b/rosie/rosie/chamber_of_deputies/tests/test_adapter.py
@@ -83,7 +83,6 @@ class TestAdapter(TestCase):
         ))
         fetch.assert_called_once_with(Adapter.COMPANIES_DATASET, self.temp_path)
 
-    @freeze_time('2010-11-12')
     @patch('rosie.chamber_of_deputies.adapter.fetch')
     @patch('rosie.chamber_of_deputies.adapter.Reimbursements')
     def test_coerce_situation_date(self, reimbursements, fetch):


### PR DESCRIPTION
**What is the purpose of this Pull Request?** 
Big picture: to improve the stage of coercing dates.
- Specify a format when converting issue_field do datetime, to make clear what format we expect as input.
- Fix a bug on coercing situation_date and tuning performance of this stage.
 The bug is after coercing situation_date without specifying the format, many dates were with day/month instead month/day, (ex: 05/11/2017 were coercing to 2017-05-11).
  The initial focus of my work was tuning the performance of the coerce situation_date stage:
 - a DataFrame with 1860489 items was taking 140 seconds to coerce situation_date. After specifying the format, it was taking 10 seconds

**What was done to achieve this purpose?**
  It was specified a format when coercing these date fields

**How to test if it really works?**
  There are new unit tests. Just run pytest.
  You can also run rosie.py run chamber_of_deputies to check the performance of this stage and final output is the same (suspicions.xz)

**Who can help reviewing it?**
  @cuducos @Irio 
