### PR TITLE
Filter reimbursements by state

### DIFF
--- a/jarbas/README.md
+++ b/jarbas/README.md
@@ -59,6 +59,7 @@ All these endpoints accepts any combination of the following parameters:
 * `suspicions` (_boolean_, `1` parses to `True`, `0` to `False`)
 * `has_receipt` (_boolean_, `1` parses to `True`, `0` to `False`)
 * `year`
+* `state`
 * `order_by`: `issue_date` (default) or `probability` (both descending)
 * `in_latest_dataset` (_boolean_, `1` parses to `True`, `0` to `False`)
 * `search` (Search the value in any of the fields below)

--- a/jarbas/chamber_of_deputies/querysets.py
+++ b/jarbas/chamber_of_deputies/querysets.py
@@ -86,6 +86,7 @@ def _str_to_tuple(filters):
 def _rename_key(key):
     mapping = dict(
         issue_date_start='issue_date__gte',
-        issue_date_end='issue_date__lt'
+        issue_date_end='issue_date__lt',
+        state='state__iexact'
     )
     return mapping.get(key, key)

--- a/jarbas/chamber_of_deputies/tests/test_reimbursement_view.py
+++ b/jarbas/chamber_of_deputies/tests/test_reimbursement_view.py
@@ -1,4 +1,3 @@
-import sys
 from json import loads
 from unittest.mock import patch
 from urllib.parse import urlencode

--- a/jarbas/chamber_of_deputies/tests/test_reimbursement_view.py
+++ b/jarbas/chamber_of_deputies/tests/test_reimbursement_view.py
@@ -95,6 +95,17 @@ class TestListApi(TestCase):
         content = loads(resp.content.decode('utf-8'))
         self.assertEqual(2, len(content['results']))
 
+    def test_content_with_state_filter(self):
+        get_reimbursement(quantity=2, state="SP")
+        get_reimbursement(state="PR")
+        search_data = (
+            ('state', "SP"),
+        )
+        url = '{}?{}'.format(self.url, urlencode(search_data))
+        resp = self.client.get(url)
+        content = loads(resp.content.decode('utf-8'))
+        self.assertEqual(2, len(content['results']))
+
     def test_content_with_applicant_id_filter(self):
         get_reimbursement(quantity=2, applicant_id=221)
         get_reimbursement(applicant_id=345)

--- a/jarbas/chamber_of_deputies/views.py
+++ b/jarbas/chamber_of_deputies/views.py
@@ -24,7 +24,8 @@ class ReimbursementListView(ListAPIView):
             'issue_date_start',
             'month',
             'subquota_number',
-            'year'
+            'year',
+            'state'
         )
         values = map(self.request.query_params.get, params)
         filters = {k: v for k, v in zip(params, values) if v}


### PR DESCRIPTION
<!-- Thank you for contributing with us -->
<!-- This is just a template to help you make your point clear with this PR. :) --> 

**What is the purpose of this Pull Request?**
This Pull Request add a state filter to the reimbursement view endpoint

**What was done to achieve this purpose?**
`state` was added to the list of params of the ReimbursementListView using the lookup [`iexact` (Case-insensitive exact match.)](https://docs.djangoproject.com/en/2.1/ref/models/querysets/#iexact).

**How to test if it really works?**
`docker-compose run --rm django python manage.py test jarbas.chamber_of_deputies.tests.test_reimbursement_view.TestListApi.test_content_with_state_filter`

**Who can help reviewing it?**
Anyone who knows the api =)

It closes the issue #402 