### PR TITLE
Support masked CNPJ/CPF on the search

### DIFF
--- a/jarbas/chamber_of_deputies/serializers.py
+++ b/jarbas/chamber_of_deputies/serializers.py
@@ -1,3 +1,5 @@
+import re
+
 from rest_framework import serializers
 
 from jarbas.chamber_of_deputies.models import Reimbursement
@@ -128,3 +130,9 @@ def format_cnpj(cnpj):
         cnpj[8:12],
         cnpj[12:14]
     )
+
+
+def clean_cnpj_cpf(value):
+    for document in re.findall(r"[\d.-]{14}|[\d./-]{18}", value):
+        value = value.replace(document, re.sub(r"\D", "", document))
+    return value

--- a/jarbas/chamber_of_deputies/tests/test_reimbursement_view.py
+++ b/jarbas/chamber_of_deputies/tests/test_reimbursement_view.py
@@ -4,7 +4,6 @@ from urllib.parse import urlencode
 
 from django.core.management import call_command
 from django.shortcuts import resolve_url
-from django.utils.six import StringIO
 from django.test import TestCase
 from freezegun import freeze_time
 from mixer.backend.django import mixer
@@ -53,6 +52,34 @@ class TestListApi(TestCase):
     def test_content_with_cnpj_cpf_filter(self):
         search_data = (
             ('cnpj_cpf', '12345678901'),
+            ('subquota_number', '22'),
+            ('order_by', 'probability'),
+            ('suspicions', '1'),
+        )
+        url = '{}?{}'.format(self.url, urlencode(search_data))
+        target_result = get_reimbursement(cnpj_cpf='12345678901', subquota_number=22, suspicions=1)
+        resp = self.client.get(url)
+        content = loads(resp.content.decode('utf-8'))
+        self.assertEqual(1, len(content['results']))
+        self.assertEqual(target_result.cnpj_cpf, content['results'][0]['cnpj_cpf'])
+
+    def test_content_with_masked_cnpj(self):
+        search_data = (
+            ('cnpj_cpf', '07.575.651/0001-59'),
+            ('subquota_number', '22'),
+            ('order_by', 'probability'),
+            ('suspicions', '1'),
+        )
+        url = '{}?{}'.format(self.url, urlencode(search_data))
+        target_result = get_reimbursement(cnpj_cpf='07575651000159', subquota_number=22, suspicions=1)
+        resp = self.client.get(url)
+        content = loads(resp.content.decode('utf-8'))
+        self.assertEqual(1, len(content['results']))
+        self.assertEqual(target_result.cnpj_cpf, content['results'][0]['cnpj_cpf'])
+
+    def test_content_with_masked_cpf(self):
+        search_data = (
+            ('cnpj_cpf', '123.456.789-01'),
             ('subquota_number', '22'),
             ('order_by', 'probability'),
             ('suspicions', '1'),

--- a/jarbas/chamber_of_deputies/tests/test_serializers.py
+++ b/jarbas/chamber_of_deputies/tests/test_serializers.py
@@ -1,0 +1,11 @@
+from django.test import TestCase
+
+from jarbas.chamber_of_deputies.serializers import clean_cnpj_cpf
+
+
+class TestCleanCnpjCpf(TestCase):
+    def test_should_return_cnpj_cpf_without_mask(self):
+        self.assertEqual('12345678901234', clean_cnpj_cpf('12.345.678/9012-34'))
+        self.assertEqual('12345678901234', clean_cnpj_cpf('12345678901234'))
+        self.assertEqual('02002002002', clean_cnpj_cpf('020.020.020-02'))
+        self.assertEqual('02002002002', clean_cnpj_cpf('02002002002'))

--- a/jarbas/chamber_of_deputies/views.py
+++ b/jarbas/chamber_of_deputies/views.py
@@ -5,7 +5,7 @@ from jarbas.chamber_of_deputies.serializers import (ReimbursementSerializer,
                                                     ReceiptSerializer,
                                                     SameDayReimbursementSerializer,
                                                     ApplicantSerializer,
-                                                    SubquotaSerializer)
+                                                    SubquotaSerializer, clean_cnpj_cpf)
 
 
 class ReimbursementListView(ListAPIView):
@@ -29,6 +29,9 @@ class ReimbursementListView(ListAPIView):
         )
         values = map(self.request.query_params.get, params)
         filters = {k: v for k, v in zip(params, values) if v}
+
+        if filters.get('cnpj_cpf'):
+            filters['cnpj_cpf'] = clean_cnpj_cpf(filters['cnpj_cpf'])
 
         # filter suspicions
         suspicions = self._bool_param('suspicions')

--- a/jarbas/dashboard/admin/__init__.py
+++ b/jarbas/dashboard/admin/__init__.py
@@ -5,6 +5,7 @@ from django.db.models import F
 from django.utils.safestring import mark_safe
 
 from jarbas.chamber_of_deputies.models import Reimbursement
+from jarbas.chamber_of_deputies.serializers import clean_cnpj_cpf
 from jarbas.dashboard.admin import list_filters, widgets
 from jarbas.dashboard.admin.paginators import CachedCountPaginator
 from jarbas.dashboard.admin.subquotas import Subquotas
@@ -136,6 +137,8 @@ class ReimbursementModelAdmin(PublicAdminModelAdmin):
             .get_search_results(request, queryset, None)
 
         if search_term:
+            # if a cnpj/cpf strip characters other than digits
+            search_term = clean_cnpj_cpf(search_term)
             query = SearchQuery(search_term, config='portuguese')
             rank = SearchRank(F('search_vector'), query)
             queryset = queryset.annotate(rank=rank).filter(search_vector=query)


### PR DESCRIPTION
<!-- Thank you for contributing with us -->
<!-- This is just a template to help you make your point clear with this PR. :) --> 

**What is the purpose of this Pull Request?**
<!-- Tell here how this can help this project -->
Resolves https://github.com/okfn-brasil/serenata-de-amor/issues/448. Currently is not possible to retrieve imbursements from a masked CNPJ/CPF.

**What was done to achieve this purpose?**
<!-- Explain what was done to make it work -->
Now both AdminSite and API has a method to clean masked CNPJ/CPF.

**How to test if it really works?**
<!-- Write how could it be tested and checked here -->
Run Jarbas and test the search by using a masked and a not masked CNPJ or CPF. Like: 07575651000159 and 07.575.651/0001-59. Both must return the same results.

**Who can help reviewing it?**
<!-- Who are the best people to help reviews it? -->
@cuducos maybe? :) I've used his snipet code.

**TODO**
Searching by CNPJ/CPF is only possible if a user types the whole document (14 or 18 characters). Maybe would be nice adding support to partial CNPJ/CPF.