### PR TITLE
fix bug addressed when cpfcnpj has . or - when querying database

### DIFF
--- a/jarbas/chamber_of_deputies/querysets.py
+++ b/jarbas/chamber_of_deputies/querysets.py
@@ -60,6 +60,10 @@ class ReimbursementQuerySet(models.QuerySet):
 
         return self
 
+    def cnpj_cpf(self, value):
+        cleaned_value = ''.join(e for e in value if e.isalnum())
+        return self.filter(Q(cnpj_cpf=value) | Q(cnpj_cpf=cleaned_value))
+
 
 def _str_to_tuple(filters):
     """

--- a/jarbas/chamber_of_deputies/tests/test_reimbursement_view.py
+++ b/jarbas/chamber_of_deputies/tests/test_reimbursement_view.py
@@ -64,6 +64,34 @@ class TestListApi(TestCase):
         self.assertEqual(1, len(content['results']))
         self.assertEqual(target_result.cnpj_cpf, content['results'][0]['cnpj_cpf'])
 
+    def test_content_with_cnpj_cpf_filter_dot_dash(self):
+        search_data = (
+            ('cnpj_cpf', '12345678901'),
+            ('subquota_number', '22'),
+            ('order_by', 'probability'),
+            ('suspicions', '1'),
+        )
+        url = '{}?{}'.format(self.url, urlencode(search_data))
+        target_result = get_reimbursement(cnpj_cpf='123.456.789-01', subquota_number=22, suspicions=1)
+        resp = self.client.get(url)
+        content = loads(resp.content.decode('utf-8'))
+        self.assertEqual(1, len(content['results']))
+        self.assertEqual(target_result.cnpj_cpf, content['results'][0]['cnpj_cpf'])
+
+    def test_content_with_cnpj_cpf_filter_dash(self):
+        search_data = (
+            ('cnpj_cpf', '12345678901'),
+            ('subquota_number', '22'),
+            ('order_by', 'probability'),
+            ('suspicions', '1'),
+        )
+        url = '{}?{}'.format(self.url, urlencode(search_data))
+        target_result = get_reimbursement(cnpj_cpf='123456789-01', subquota_number=22, suspicions=1)
+        resp = self.client.get(url)
+        content = loads(resp.content.decode('utf-8'))
+        self.assertEqual(1, len(content['results']))
+        self.assertEqual(target_result.cnpj_cpf, content['results'][0]['cnpj_cpf'])
+
     def test_content_with_date_filters(self):
         get_reimbursement(issue_date='1970-01-01')
         get_reimbursement(issue_date='1970-01-01')

--- a/jarbas/chamber_of_deputies/views.py
+++ b/jarbas/chamber_of_deputies/views.py
@@ -30,7 +30,6 @@ class ReimbursementListView(ListAPIView):
         values = map(self.request.query_params.get, params)
         filters = {k: v for k, v in zip(params, values) if v}
 
-
         # filter cpf or cnpj without dot and dash
         hasCfpCnpj = self._bool_param('cnpj_cpf')
         if hasCfpCnpj is not None:

--- a/jarbas/chamber_of_deputies/views.py
+++ b/jarbas/chamber_of_deputies/views.py
@@ -30,6 +30,12 @@ class ReimbursementListView(ListAPIView):
         values = map(self.request.query_params.get, params)
         filters = {k: v for k, v in zip(params, values) if v}
 
+
+        # filter cpf or cnpj without dot and dash
+        hasCfpCnpj = self._bool_param('cnpj_cpf')
+        if hasCfpCnpj is not None:
+            self.queryset = self.queryset.cnpj_cpf(request.query_params.get('cnpj_cpf'))
+
         # filter suspicions
         suspicions = self._bool_param('suspicions')
         if suspicions is not None:


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
https://github.com/okfn-brasil/serenata-de-amor/issues/448
Correct cases where there is some dot or dash in the cnpj_cpf property and it queryes the database

**What was done to achieve this purpose?**
added a method filter that includes in the query a or and query the values without the dashs and dots in cnpj_cpf

**How to test if it really works?**
There are some tests added that address that problem. It passed

**Who can help reviewing it?**
@cuducos 

I think we should add a new column or a property in the model, called "cnpj_cpf_normalized" 
and add that atribute as a or to the filter, this willl solve the cases where in the database there is a values not normalized such as:
123.456.789-00 --> covered in test cases
123.456789-00
123.45678900
123456.78900
12345678900 --> covered in test cases
the cases above are covered in query when it comes from the query_params attribute, but not when the value is persisted in the database. If the value is not normalized in database it will fail.
OR we can guarantee that there is only normalized data (a.k.a. only numbers) in the backend (postgres) some ETL when adding data to the database.
