### PR TITLE
Fix update: long processes where failing

### DIFF
--- a/contrib/update/README.md
+++ b/contrib/update/README.md
@@ -34,7 +34,7 @@ $ pipenv run ansible-playbook update.yml
 To make sure the ephemeral DigitalOcean droplet was destroyed:
 
 ```console
-$ pipenv run ansible-playbook cleanup.yml
+$ pipenv run python cleanup.py
 ```
 
 ## Warning

--- a/contrib/update/ansible.cfg
+++ b/contrib/update/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 host_key_checking = False
+ServerAliveInterval=30

--- a/contrib/update/cleanup.py
+++ b/contrib/update/cleanup.py
@@ -1,0 +1,40 @@
+from os import getenv
+
+from dopy.manager import DoManager
+
+
+NAME = "serenata-update"
+
+
+def get_id(objects):
+    for object in objects:
+        if object["name"] == NAME:
+            return object["id"]
+
+
+def destroy_droplet(manager):
+    droplet = get_id(manager.all_active_droplets())
+    if not droplet:
+        print "Droplet {} not found.".format(NAME)
+        return
+
+    output = manager.destroy_droplet(droplet)
+    print "Droplet {} ({}) deleted.".format(NAME, droplet)
+    return output
+
+
+def destroy_ssh_key(manager):
+    ssh_key = get_id(manager.all_ssh_keys())
+    if not ssh_key:
+        print "SSH key {} not found.".format()
+        return
+
+    output = manager.destroy_ssh_key(ssh_key)
+    print "SSH key {} ({}) deleted.".format(NAME, ssh_key)
+    return output
+
+
+if __name__ == "__main__":
+    manager = DoManager(None, getenv("DO_API_TOKEN"), api_version=2)
+    destroy_droplet(manager)
+    destroy_ssh_key(manager)

--- a/contrib/update/cleanup.py
+++ b/contrib/update/cleanup.py
@@ -6,35 +6,22 @@ from dopy.manager import DoManager
 NAME = "serenata-update"
 
 
-def get_id(objects):
-    for object in objects:
-        if object["name"] == NAME:
-            return object["id"]
-
-
 def destroy_droplet(manager):
-    droplet = get_id(manager.all_active_droplets())
-    if not droplet:
-        print "Droplet {} not found.".format(NAME)
+    droplet_id = None
+    for droplet in manager.all_active_droplets():
+        if droplet["name"] == NAME:
+            droplet_id = droplet["id"]
+            break
+
+    if not droplet_id:
+        print("Droplet {} not found.".format(NAME))
         return
 
-    output = manager.destroy_droplet(droplet)
-    print "Droplet {} ({}) deleted.".format(NAME, droplet)
-    return output
-
-
-def destroy_ssh_key(manager):
-    ssh_key = get_id(manager.all_ssh_keys())
-    if not ssh_key:
-        print "SSH key {} not found.".format()
-        return
-
-    output = manager.destroy_ssh_key(ssh_key)
-    print "SSH key {} ({}) deleted.".format(NAME, ssh_key)
+    output = manager.destroy_droplet(droplet_id)
+    print("Droplet {} ({}) deleted.".format(NAME, droplet_id))
     return output
 
 
 if __name__ == "__main__":
     manager = DoManager(None, getenv("DO_API_TOKEN"), api_version=2)
     destroy_droplet(manager)
-    destroy_ssh_key(manager)

--- a/contrib/update/cleanup.yml
+++ b/contrib/update/cleanup.yml
@@ -1,8 +1,0 @@
-- name: destroy instance
-  hosts: localhost
-
-  tasks:
-    - name: destroy droplet
-      digital_ocean:
-        state: deleted
-        name: serenata-update

--- a/contrib/update/update.yml
+++ b/contrib/update/update.yml
@@ -96,6 +96,8 @@
   tasks:
     - name: run jarbas to update data from the chamber of deputies
       shell: python3 manage.py update /tmp/serenata-data
+      async: 10800
+      poll: 15
       args:
         chdir: /opt/serenata-de-amor/
       environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.1.5
+Django==2.1.7
 brazilnum==0.8.8
 celery==4.2.1
 dj-database-url==0.5.0


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
Jarbas `update` command was taking too long and causing Ansible to crash with a SSH connection error. Also the `cleanup.yml` was failing (from times to times) to remove the existing droplet.

**What was done to achieve this purpose?**
* Set Ansible to better deal with processes that take too long, using `async` strategy
* Replace the cleanup playbook by a Python script

**How to test if it really works?**
Having access to DigitalOcean droplets, just run the Ansible playbook as documented in `contrib/update`.