### PR TITLE
Add summary table and charts to the Dashboard

### DIFF
--- a/jarbas/chamber_of_deputies/models.py
+++ b/jarbas/chamber_of_deputies/models.py
@@ -137,6 +137,14 @@ class Reimbursement(models.Model):
         return 'Documento nº {}'.format(self.document_id)
 
 
+class ReimbursementSummary(Reimbursement):
+
+    class Meta:
+        proxy = True
+        verbose_name = 'resumo do reembolso'
+        verbose_name_plural = 'resumo dos reembolsos'
+
+
 class Tweet(models.Model):
 
     reimbursement = models.OneToOneField(Reimbursement, on_delete=models.CASCADE, db_index=True)

--- a/jarbas/dashboard/admin/__init__.py
+++ b/jarbas/dashboard/admin/__init__.py
@@ -1,4 +1,4 @@
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from hashlib import md5
 
 from brazilnum.cnpj import format_cnpj
@@ -191,7 +191,7 @@ class ReimbursementSummaryModelAdmin(PublicAdminModelAdmin):
 
         try:
             percentage = (total - low) / (high - low)
-        except ZeroDivisionError:
+        except InvalidOperation:
             percentage = Decimal('0')
 
         ratio = Decimal('1') - minimum_percentage

--- a/jarbas/dashboard/admin/__init__.py
+++ b/jarbas/dashboard/admin/__init__.py
@@ -254,6 +254,8 @@ class ReimbursementSummaryModelAdmin(PublicAdminModelAdmin):
         }
 
         context = {
+            'year': request.GET.get('year'),
+            'month': request.GET.get('month'),
             'chart_grouping': chart_grouping,
             'summary': tuple(queryset),
             'summary_total': dict(queryset.aggregate(**metrics)),

--- a/jarbas/dashboard/admin/__init__.py
+++ b/jarbas/dashboard/admin/__init__.py
@@ -1,10 +1,10 @@
 from decimal import Decimal
 
-from django.db.models.functions import Trunc
 from brazilnum.cnpj import format_cnpj
 from brazilnum.cpf import format_cpf
 from django.contrib.postgres.search import SearchQuery, SearchRank
 from django.db.models import Count, DateField, F, Max, Min, Sum
+from django.db.models.functions import Trunc
 from django.utils.safestring import mark_safe
 
 from jarbas.chamber_of_deputies.models import (
@@ -157,12 +157,17 @@ class ReimbursementModelAdmin(PublicAdminModelAdmin):
 
 class ReimbursementSummaryModelAdmin(PublicAdminModelAdmin):
     change_list_template = 'dashboard/reimbursement_summary_change_list.html'
-    date_hierarchy = 'issue_date'
+    list_filter = (
+        list_filters.SuspiciousListFilter,
+        list_filters.HasReimbursementNumberFilter,
+        list_filters.StateListFilter,
+        list_filters.YearListFilter,
+        list_filters.MonthListFilter,
+        list_filters.DocumentTypeListFilter,
+    )
 
     def get_next_in_date_hierarchy(self, request):
-        if f'{self.date_hierarchy}__month' in request.GET:
-            return 'day'
-        if f'{self.date_hierarchy}__year' in request.GET:
+        if 'year' in request.GET:
             return 'month'
         return 'year'
 

--- a/jarbas/dashboard/static/dashboard.css
+++ b/jarbas/dashboard/static/dashboard.css
@@ -22,18 +22,18 @@ label.required {
 
 .bar-chart {
   display: flex;
-  justify-content: space-around;
   height: 160px;
-  padding-top: 60px;
+  justify-content: space-around;
   overflow: hidden;
+  padding-top: 60px;  /* csslint allow: box-model */
 }
 
 .bar-chart .bar {
-  flex: 100%;
   align-self: flex-end;
+  background-color: #79aec8;
+  flex: 100%;
   margin-right: 2px;
   position: relative;
-  background-color: #79aec8;
 }
 
 .bar-chart .bar:last-child {
@@ -50,13 +50,13 @@ label.required {
 }
 
 .bar-chart .bar .bar-tooltip {
-  position: absolute;
-  top: -3rem;
-  left: 50%;
-  transform: translateX(-50%);
-  text-align: center;
-  opacity: 0;
   font-size: 0.68rem;
+  left: 50%;
+  opacity: 0;
+  position: absolute;
+  text-align: center;
+  top: -3rem;
+  transform: translateX(-50%);
 }
 
 .bar-chart .bar:hover .bar-tooltip {

--- a/jarbas/dashboard/static/dashboard.css
+++ b/jarbas/dashboard/static/dashboard.css
@@ -20,7 +20,7 @@ label.required {
   font-weight: normal
 }
 
-#changelist-form div.results {
+#changelist-form .results {
   width: calc(calc(100% - 240px) - 1rem); /* 240px is the filter tab width */
 }
 

--- a/jarbas/dashboard/static/dashboard.css
+++ b/jarbas/dashboard/static/dashboard.css
@@ -20,6 +20,10 @@ label.required {
   font-weight: normal
 }
 
+#changelist-form div.results {
+  width: calc(calc(100% - 240px) - 1rem); /* 240px is the filter tab width */
+}
+
 .bar-chart {
   display: flex;
   height: 160px;

--- a/jarbas/dashboard/static/dashboard.css
+++ b/jarbas/dashboard/static/dashboard.css
@@ -19,3 +19,46 @@ label.required {
   color: #666;
   font-weight: normal
 }
+
+.bar-chart {
+  display: flex;
+  justify-content: space-around;
+  height: 160px;
+  padding-top: 60px;
+  overflow: hidden;
+}
+
+.bar-chart .bar {
+  flex: 100%;
+  align-self: flex-end;
+  margin-right: 2px;
+  position: relative;
+  background-color: #79aec8;
+}
+
+.bar-chart .bar:last-child {
+  margin: 0;
+}
+
+.bar-chart .bar:hover {
+  background-color: #417690;
+}
+
+.bar-chart .bar .bar-tooltip {
+  position: relative;
+  z-index: 999;
+}
+
+.bar-chart .bar .bar-tooltip {
+  position: absolute;
+  top: -3rem;
+  left: 50%;
+  transform: translateX(-50%);
+  text-align: center;
+  opacity: 0;
+  font-size: 0.68rem;
+}
+
+.bar-chart .bar:hover .bar-tooltip {
+  opacity: 1;
+}

--- a/jarbas/dashboard/templates/dashboard/reimbursement_summary_change_list.html
+++ b/jarbas/dashboard/templates/dashboard/reimbursement_summary_change_list.html
@@ -6,7 +6,7 @@
 {% endblock %}
 
 {% block result_list %}
-<div class=”results”>
+<div class="results">
     <table>
 
     <thead>
@@ -66,7 +66,7 @@
 <p>&nbsp;</p>
 
 {% if summary_over_time|length > 1 %}
-	<div class="resullts">
+	<div class="results">
 		<h2>Reembolsos por período (por {{ period|translate_period }})</h2>
 		<div class="bar-chart">
 			{% for data in summary_over_time %}

--- a/jarbas/dashboard/templates/dashboard/reimbursement_summary_change_list.html
+++ b/jarbas/dashboard/templates/dashboard/reimbursement_summary_change_list.html
@@ -67,16 +67,16 @@
 
 {% if summary_over_time|length > 1 %}
   <div class="results">
-    <h2>Reembolsos por período (por {{ period|translate_period }})</h2>
+    <h2>Reembolsos por período (por {{ chart_grouping|translate_chart_grouping }})</h2>
     <div class="bar-chart">
       {% for data in summary_over_time %}
       <div class="bar" style="height:{{ data.percent }}%">
         <div class="bar-tooltip">
           {{ data.total|brazilian_reais }}<br>
-          {% if period == 'year' %}
-            {{ data.period|period_as_date|date:"Y"}}
+          {% if chart_grouping == 'year' %}
+            {{ data.chart_grouping|chart_grouping_as_date|date:"Y"}}
           {% else %}
-            {{ data.period|period_as_date|date:"m/Y"}}
+            {{ data.chart_grouping|chart_grouping_as_date|date:"m/Y"}}
           {% endif %}
         </div>
       </div>

--- a/jarbas/dashboard/templates/dashboard/reimbursement_summary_change_list.html
+++ b/jarbas/dashboard/templates/dashboard/reimbursement_summary_change_list.html
@@ -1,0 +1,94 @@
+{% extends "admin/change_list.html" %}
+{% load dashboard %}
+
+{% block content_title %}
+    <h1>Resumo dos reembolsos da CEAP</h1>
+{% endblock %}
+
+{% block result_list %}
+<div class=”results”>
+    <table>
+
+    <thead>
+      <tr>
+        <th>
+          <div class=”text”>
+            <a href=”#”>Categoria (sub-cota)</a>
+          </div>
+        </th>
+        <th>
+          <div class=”text”>
+            <a href=”#”>Número de reembolsos</a>
+          </div>
+        </th>
+        <th>
+          <div class=”text”>
+            <a href=”#”>Valor total</a>
+          </div>
+        </th>
+        <th>
+          <div class=”text”>
+            <a href=”#”>
+              <strong>% do total</strong>
+            </a>
+          </div>
+        </th>
+      </tr>
+    </thead>
+
+    <tbody>
+      {% for row in summary %}
+      <tr class=”{% cycle 'row1' 'row2' %}”>
+        <td>{{ row.subquota_description|translate_subquota }}</td>
+        <td>{{ row.total_reimbursements|brazilian_integer }}</td>
+        <td>{{ row.total_value|brazilian_reais }}</td>
+        <td>
+          <strong>
+            {{ row.total_value|default:0|percentof:summary_total.total_value }}
+          </strong>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+
+    <tfoot>
+      <tr style=”font-weight:bold; border-top:2px solid #DDDDDD;”>
+        <td> Total </td>
+        <td>{{ summary_total.total_reimbursements|brazilian_integer }}</td>
+        <td>{{ summary_total.total_value|brazilian_reais }}</td>
+        <td>100%</td>
+      </tr>
+    </tfoot>
+
+  </table>
+</div>
+
+<p>&nbsp;</p>
+
+{% if summary_over_time|length > 1 %}
+	<div class="resullts">
+		<h2>Reembolsos por período (por {{ period|translate_period }})</h2>
+		<div class="bar-chart">
+			{% for data in summary_over_time %}
+			<div class="bar" style="height:{{ data.percent }}%">
+				<div class="bar-tooltip">
+					{{ data.total|brazilian_reais }}<br>
+					{% if period == 'year' %}
+						{{ data.period|date:"Y"}}
+					{% elif period == 'month' %}
+						{{ data.period|date:"m/Y"}}
+					{% else %}
+						{{ data.period|date:"d/m/Y"}}
+					{% endif %}
+				</div>
+			</div>
+			{% endfor %}
+		</div>
+	</div>
+
+	</div>
+{% endif %}
+
+{% endblock %}
+
+{% block pagination %}{% endblock %}

--- a/jarbas/dashboard/templates/dashboard/reimbursement_summary_change_list.html
+++ b/jarbas/dashboard/templates/dashboard/reimbursement_summary_change_list.html
@@ -66,27 +66,25 @@
 <p>&nbsp;</p>
 
 {% if summary_over_time|length > 1 %}
-	<div class="results">
-		<h2>Reembolsos por período (por {{ period|translate_period }})</h2>
-		<div class="bar-chart">
-			{% for data in summary_over_time %}
-			<div class="bar" style="height:{{ data.percent }}%">
-				<div class="bar-tooltip">
-					{{ data.total|brazilian_reais }}<br>
-					{% if period == 'year' %}
-						{{ data.period|date:"Y"}}
-					{% elif period == 'month' %}
-						{{ data.period|date:"m/Y"}}
-					{% else %}
-						{{ data.period|date:"d/m/Y"}}
-					{% endif %}
-				</div>
-			</div>
-			{% endfor %}
-		</div>
-	</div>
+  <div class="results">
+    <h2>Reembolsos por período (por {{ period|translate_period }})</h2>
+    <div class="bar-chart">
+      {% for data in summary_over_time %}
+      <div class="bar" style="height:{{ data.percent }}%">
+        <div class="bar-tooltip">
+          {{ data.total|brazilian_reais }}<br>
+          {% if period == 'year' %}
+            {{ data.period|period_as_date|date:"Y"}}
+          {% else %}
+            {{ data.period|period_as_date|date:"m/Y"}}
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
 
-	</div>
+  </div>
 {% endif %}
 
 {% endblock %}

--- a/jarbas/dashboard/templates/dashboard/reimbursement_summary_change_list.html
+++ b/jarbas/dashboard/templates/dashboard/reimbursement_summary_change_list.html
@@ -2,7 +2,13 @@
 {% load dashboard %}
 
 {% block content_title %}
-    <h1>Resumo dos reembolsos da CEAP</h1>
+    <h1>
+      Resumo dos reembolsos da CEAP
+      {% if year or month %}-{% endif %}
+      {% if month %}{{ month }}{% endif %}
+      {% if year and month %}/{% endif %}
+      {% if year %}{{ year }}{% endif %}
+    </h1>
 {% endblock %}
 
 {% block result_list %}

--- a/jarbas/dashboard/templatetags/dashboard.py
+++ b/jarbas/dashboard/templatetags/dashboard.py
@@ -32,7 +32,8 @@ def brazilian_reais(value):
 def brazilian_float(value):
     value = value or 0
     value = f'{value:,.2f}'
-    return value.replace(',', 'x').replace('.', ',').replace('x', '.')
+    translation = value.maketrans(',.', '.,')
+    return value.translate(translation)
 
 
 @register.filter()

--- a/jarbas/dashboard/templatetags/dashboard.py
+++ b/jarbas/dashboard/templatetags/dashboard.py
@@ -50,13 +50,13 @@ def translate_subquota(value):
 
 
 @register.filter()
-def translate_period(value):
+def translate_chart_grouping(value):
     translation = {'month': 'mês', 'year': 'ano'}
     return translation.get(value, value)
 
 
 @register.filter()
-def period_as_date(value):
+def chart_grouping_as_date(value):
     """Transforms a string YYYYMM or YYYY in a date object"""
     value = str(value)
     for format in ('%Y', '%Y%m'):

--- a/jarbas/dashboard/templatetags/dashboard.py
+++ b/jarbas/dashboard/templatetags/dashboard.py
@@ -5,6 +5,7 @@ from django.template.defaultfilters import stringfilter
 from jarbas.dashboard.admin.subquotas import Subquotas
 
 
+BR_NUMBER_TRANSLATION = str.maketrans(',.', '.,')
 register = template.Library()
 
 
@@ -33,15 +34,14 @@ def brazilian_reais(value):
 def brazilian_float(value):
     value = value or 0
     value = f'{value:,.2f}'
-    translation = value.maketrans(',.', '.,')
-    return value.translate(translation)
+    return value.translate(BR_NUMBER_TRANSLATION)
 
 
 @register.filter()
 def brazilian_integer(value):
     value = value or 0
     value = f'{value:,.0f}'
-    return value.replace(',', '.')
+    return value.translate(BR_NUMBER_TRANSLATION)
 
 
 @register.filter()

--- a/jarbas/dashboard/templatetags/dashboard.py
+++ b/jarbas/dashboard/templatetags/dashboard.py
@@ -1,6 +1,8 @@
 from django import template
 from django.template.defaultfilters import stringfilter
 
+from jarbas.dashboard.admin.subquotas import Subquotas
+
 
 register = template.Library()
 
@@ -11,3 +13,47 @@ def rename_title(title):
     title = title.replace('modificar', 'visualizar')
     title = title.replace('Modificar', 'Visualizar')
     return title
+
+
+@register.filter()
+def percentof(amount, total):
+    try:
+        return f'{brazilian_float(amount * 100 / total)}%'
+    except ZeroDivisionError:
+        return None
+
+
+@register.filter()
+def brazilian_reais(value):
+    return f'R$ {brazilian_float(value)}'
+
+
+@register.filter()
+def brazilian_float(value):
+    # TODO properly use locales
+    value = value or 0
+    value = f'{value:,.2f}'
+    return value.replace(',', 'x').replace('.', ',').replace('x', '.')
+
+
+@register.filter()
+def brazilian_integer(value):
+    # TODO properly use locales
+    value = value or 0
+    value = f'{value:,.0f}'
+    return value.replace(',', '.')
+
+
+@register.filter()
+def translate_subquota(value):
+    return Subquotas.pt_br(value) or value
+
+
+@register.filter()
+def translate_period(value):
+    translation = {
+        'day': 'dia',
+        'month': 'mês',
+        'year': 'ano'
+    }
+    return translation.get(value, value)

--- a/jarbas/dashboard/templatetags/dashboard.py
+++ b/jarbas/dashboard/templatetags/dashboard.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from django import template
 from django.template.defaultfilters import stringfilter
 
@@ -52,3 +53,14 @@ def translate_subquota(value):
 def translate_period(value):
     translation = {'month': 'mês', 'year': 'ano'}
     return translation.get(value, value)
+
+
+@register.filter()
+def period_as_date(value):
+    """Transforms a string YYYYMM or YYYY in a date object"""
+    value = str(value)
+    for format in ('%Y', '%Y%m'):
+        try:
+            return datetime.strptime(str(value), format).date()
+        except ValueError:
+            pass

--- a/jarbas/dashboard/templatetags/dashboard.py
+++ b/jarbas/dashboard/templatetags/dashboard.py
@@ -50,9 +50,5 @@ def translate_subquota(value):
 
 @register.filter()
 def translate_period(value):
-    translation = {
-        'day': 'dia',
-        'month': 'mês',
-        'year': 'ano'
-    }
+    translation = {'month': 'mês', 'year': 'ano'}
     return translation.get(value, value)

--- a/jarbas/dashboard/templatetags/dashboard.py
+++ b/jarbas/dashboard/templatetags/dashboard.py
@@ -30,7 +30,6 @@ def brazilian_reais(value):
 
 @register.filter()
 def brazilian_float(value):
-    # TODO properly use locales
     value = value or 0
     value = f'{value:,.2f}'
     return value.replace(',', 'x').replace('.', ',').replace('x', '.')
@@ -38,7 +37,6 @@ def brazilian_float(value):
 
 @register.filter()
 def brazilian_integer(value):
-    # TODO properly use locales
     value = value or 0
     value = f'{value:,.0f}'
     return value.replace(',', '.')


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
Based on @hakib's post (many thanks!) [How to turn Django Admin into a lightweight dashboard](https://hakibenita.com/how-to-turn-django-admin-into-a-lightweight-dashboard) I suggested an implementation for Jarbas. This might be useful for non-tech people interested in an simple overview of CEAP (cc @tatianasb and @vilapedro).

**What was done to achieve this purpose?**
Basically followed the steps in @hakib's post.

**How to test if it really works?**
Run Jarbas, reach `/dashboard/chamber_of_deputies/reimbursementsummary/` and expect I expect you can browse in an interface like this one:
![image](https://user-images.githubusercontent.com/4732915/52890927-93f54880-316e-11e9-9c18-c45fd4f0ef5b.png)


**Who can help reviewing it?**
Just thinking out loud depending on each one's interest and availability: @jtemporal @giovanisleite @cabral @turicas @irio @leportella 