### PR TITLE
Make term field optional in Elm

### DIFF
--- a/jarbas/layers/elm/Reimbursement/Decoder.elm
+++ b/jarbas/layers/elm/Reimbursement/Decoder.elm
@@ -73,7 +73,7 @@ singleDecoder lang apiKey =
             |> required "state" (nullable string)
             |> required "party" (nullable string)
             |> required "term_id" (nullable int)
-            |> required "term" int
+            |> required "term" (nullable int)
             |> required "subquota_number" int
             |> required "subquota_description" string
             |> required "subquota_group_id" (nullable int)

--- a/jarbas/layers/elm/Reimbursement/Model.elm
+++ b/jarbas/layers/elm/Reimbursement/Model.elm
@@ -24,7 +24,7 @@ type alias Reimbursement =
     , state : Maybe String
     , party : Maybe String
     , termId : Maybe Int
-    , term : Int
+    , term : Maybe Int
     , subquotaNumber : Int
     , subquotaDescription : String
     , subquotaGroupId : Maybe Int

--- a/jarbas/layers/elm/Reimbursement/View.elm
+++ b/jarbas/layers/elm/Reimbursement/View.elm
@@ -408,7 +408,7 @@ viewCongressPersonDetails lang reimbursement =
         fields =
             [ Field CongresspersonId <| viewMaybeIntButZero reimbursement.congresspersonId
             , Field CongresspersonDocument <| viewMaybeIntButZero reimbursement.congresspersonDocument
-            , Field Term <| toString reimbursement.term
+            , Field Term <| viewMaybeIntButZero reimbursement.term
             , Field TermId <| viewMaybeIntButZero reimbursement.termId
             ]
                 |> List.filter (Fields.getValue >> String.isEmpty >> not)


### PR DESCRIPTION
This is probably an error in the original datasets, as described in #457. This commit can be reverted later depending on the response from the Chamber of Deputies: https://github.com/labhackercd/dados-abertos/issues/215