### PR TITLE
Remove mentions from tweets

### DIFF
--- a/jarbas/chamber_of_deputies/twitter.py
+++ b/jarbas/chamber_of_deputies/twitter.py
@@ -16,7 +16,7 @@ class Twitter:
     TEXT = (
         '🚨Gasto suspeito de Dep. {} ({}). '
         'Você pode me ajudar a verificar? '
-        '{} #SerenataDeAmor na @CamaraDeputados'
+        '{} #SerenataDeAmor'
     )
 
     def __init__(self, mention=False):


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
Due to Twitter's suspension of Rosie API keys, we are not mentioning the chamber of deputies in the tweets (at least for now). More on this case (in Brazilian Portuguese, English version soon): https://medium.com/serenata/a-suspens%C3%A3o-da-rosie-no-twitter-mostra-como-as-regras-para-bots-ainda-precisam-ser-lapidadas-94a0ab8b0003

**What was done to achieve this purpose?**
The `Tweet` class, responsible for the logic of picking up a suspicions, writing and posting the tweet, now takes a boolean argument `mention`. And we encourage Rosie followers to mention the congressperson if they wish ; )

**How to test if it really works?**

Import the `Tweet` class and check the message is what you expect. For example:

```python
>>> from jarbas.chamber_of_deputies.twitter import Twitter
>>> twitter = Twitter()
>> twitter.message
'🚨Gasto suspeito de Dep. XXXXX XXXXX (XX). Você pode me ajudar a verificar? https://jarbas.serenata.ai/layers/#/documentId/5700809 #SerenataDeAmor'
```