### PR TITLE
Make Rosie tweet newer suspicions

### DIFF
--- a/jarbas/chamber_of_deputies/twitter.py
+++ b/jarbas/chamber_of_deputies/twitter.py
@@ -33,7 +33,7 @@ class Twitter:
     @property
     def queryset(self):
         kwargs = {
-            'issue_date__gte': datetime.now() - timedelta(days=356 * 2),
+            'issue_date__gte': datetime.now() - timedelta(days=365 * 2),
             'suspicions__meal_price_outlier': True,
             'tweet': None,
         }


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

@tatianasb suggested Rosie to tweet only suspicions within the last 2 years, not from the current (or last) legislature available.

**What was done to achieve this purpose?**

This commit implements two strategies to make Rosie tweet newer
suspicions:
* It filters reimbursements considering the last two years
* It organizes the `QuerySet` by descending issue date and returns the top
quartile