### PR TITLE
refactor: Introduce Includes

### DIFF
--- a/jarbas/dashboard/static/dashboard.js
+++ b/jarbas/dashboard/static/dashboard.js
@@ -20,7 +20,7 @@ var hash = 'documentId'; // we look only for fragments containing this word
 
 var isLayersUrl = function () {
   if (redirectedPath !== window.location.pathname) return false;
-  return window.location.hash.split('/').indexOf(hash) >= 0;
+  return window.location.hash.split('/').includes(hash);
 };
 
 var redirectToLayers = function () {


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
Only a small refactoring that helps in the readability of the code. But if you look for performance `indexOf` is more recommended.

> ## Motivation
>When using ECMAScript arrays, it is commonly desired to determine if the array includes an element. The prevailing pattern for this is
>
>```js
>if (arr.indexOf(el) !== -1) {
>    ...
>}
>```
>
>with various other possibilities, e.g. `arr.indexOf(el) >= 0`, or even `~arr.indexOf(el)`.
>
>These patterns exhibit two problems:
>
>- They fail to "say what you mean": instead of asking about whether the array includes an element, you >ask what the index of the first occurrence of that element in the array is, and then compare it or bit->twiddle it, to determine the answer to your actual question.
>- They fail for `NaN`, as `indexOf` uses Strict Equality Comparison and thus `[NaN].indexOf(NaN) === -1`.
>
>## Proposed Solution
>We propose the addition of an `Array.prototype.includes` method, such that the above patterns can be >rewritten as
>
>```js
>if (arr.includes(el)) {
>    ...
>}
>```
>
>This has almost the same semantics as the above, except that it uses the SameValueZero comparison >algorithm instead of Strict Equality Comparison, thus making `[NaN].includes(NaN)` true.
>
>Thus, this proposal solves both problems seen in existing code.
>
>We additionally add a `fromIndex` parameter, similar to `Array.prototype.indexOf` and `String.prototype.includes`, for consistency.

Information taken from: [Array.prototype.includes](https://github.com/tc39/Array.prototype.includes/)

## Bonus
[JSPerf - Includes vs indexOf](https://jsperf.co/includes-vs-indexof)
