### PR TITLE
Remove research directory from docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,14 +50,6 @@ $ docker-compose up django
 
 Then browse from [`0.0.0.0:8000`](http://0.0.0.0:8000). [Check Jarbas's `README.md` for more details](jarbas/README.md).
 
-### Running scripts from the `research` container
-
-Example to run a given script from the `research` container:
-
-```console
-$ docker-compose run --rm -v ./data:/tmp research python src/fetch_cnpj_info.py
-```
-
 ## The basics of contributing
 
 A lot of discussions about ideas take place in the [Issues](https://github.com/okfn-brasil/serenata-de-amor/issues) section. There and interacting in the Telegram group you can catch up with what's going on and also suggest new ideas.

--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ To allow people to visualize and make sense of data Rosie generates, we have cre
 
 ### How
 
-We have three main repositories [on GitHub](https://github.com/okfn-brasil). This is the _main repo_ and hosts [Rosie](rosie/README.md), [Jarbas](jarbas/README.md) and more experimental code in the `research/` directory.
-
-In addition, we have the [Whistleblower](https://github.com/okfn-brasil/whistleblower) – the tool that gives Rosie the power to tweet – and the [toolbox](https://github.com/okfn-brasil/serenata-toolbox) - a `pip` installable package to follow the [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) principle alongside our repos and modules.
+We have two main repositories [on GitHub](https://github.com/okfn-brasil). This is the _main repo_ and hosts [Rosie](rosie/README.md) and [Jarbas](jarbas/README.md). In addition, we have the [toolbox](https://github.com/okfn-brasil/serenata-toolbox) - a `pip` installable package. Yet there are experimental [notebooks](https://github.com/okfn-brasil/notebooks) maintained by the community and our [static webpage](https://github.com/okfn-brasil/serenata-website).
 
 ### When
 


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

Since 99de387e this repo doesn't host the exploratory notebooks any more, however `README.md` and `CONTRIBUTING.md` were still mentioning this directory as @ghmc91 alerted us in the Telegram group.

**What was done to achieve this purpose?**

I updated  `README.md` and `CONTRIBUTING.md` removing references to to this part of the project.

**How to test if it really works?**

Read and check whether new contents still make sense ; )

**Who can help reviewing it?**
@sergiomario 
