### PR TITLE
Modify rosie adapter to load files acording to starting year

### DIFF
--- a/rosie/rosie/chamber_of_deputies/adapter.py
+++ b/rosie/rosie/chamber_of_deputies/adapter.py
@@ -59,7 +59,8 @@ class Adapter:
         df = pd.DataFrame()
         paths = (
             str(path) for path in Path(self.path).glob('*.csv')
-            if match(self.REIMBURSEMENTS_PATTERN, path.name)
+            if match(self.REIMBURSEMENTS_PATTERN, path.name) and
+                    self.match_starting_year(path.name)
         )
 
         for path in paths:
@@ -68,6 +69,10 @@ class Adapter:
             df = df.append(year_df)
 
         return df
+
+    def match_starting_year(self, path_name):
+        file_year = int(path_name.split('-')[1].split('.')[0])
+        return file_year >= self.STARTING_YEAR
 
     def update_datasets(self):
         self.update_companies()

--- a/rosie/rosie/chamber_of_deputies/tests/test_adapter.py
+++ b/rosie/rosie/chamber_of_deputies/tests/test_adapter.py
@@ -43,7 +43,6 @@ class TestAdapter(TestCase):
             adapter.log.disabled = True
             self.dataset = adapter.dataset
 
-
     def test_load_all_years(self):
         self.assertEqual(6, len(self.dataset))
 
@@ -68,6 +67,14 @@ class TestAdapter(TestCase):
     def test_is_party_expense_category(self):
         party_expenses = self.dataset[self.dataset.is_party_expense == True]
         self.assertEqual(1, len(party_expenses))
+
+    @freeze_time('2019-02-10')
+    def test_match_starting_year(self):
+        adapter = Adapter(self.temp_path)
+        adapter.STARTING_YEAR = 2018
+        self.assertEqual(adapter.match_starting_year('reimbursements-2017.csv'), False)
+        self.assertEqual(adapter.match_starting_year('reimbursements-2018.csv'), True)
+        self.assertEqual(adapter.match_starting_year('reimbursements-2019.csv'), True)
 
     @freeze_time('2010-11-12')
     @patch('rosie.chamber_of_deputies.adapter.fetch')


### PR DESCRIPTION
<!-- Thank you for contributing with us -->
<!-- This is just a template to help you make your point clear with this PR. :) --> 

**What is the purpose of this Pull Request?**
Make it possible to to specify the starting year for the loading step of rosie algorithms. With this changes will be easier to contribute to the project with low end machines.  

**What was done to achieve this purpose?**
Was added a function to compare the year of the CSV being loaded and the parameter STARTING_YEAR. If the year of the file is greater or equal it will be loaded, else it won't.

**How to test if it really works?**
During the load process verify that only the files referring to years **after** the starting year or **in** the starting year were loaded.