### PR TITLE
add summary of reimbursement values in reimbursements list api

### DIFF
--- a/jarbas/chamber_of_deputies/paginators.py
+++ b/jarbas/chamber_of_deputies/paginators.py
@@ -1,0 +1,25 @@
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+
+
+class ReimbursementListPagination(PageNumberPagination):
+    """Paginator to show the total amount of reimbursements"""
+    def get_paginated_response(self, data):
+        return Response({
+            'summary': self.get_total_net_value(data),
+            'next': self.get_next_link(),
+            'previous': self.get_previous_link(),
+            'results': data
+        })
+
+    def get_total_net_value(self, data):
+        """Calculates the sum of reimbursements"""
+        summary = {
+            'count': self.page.paginator.count,
+            'total_positive': sum([obj['total_net_value'] if obj['total_net_value'] >= 0 else 0 for obj in data]),
+            'total_negative': sum([obj['total_net_value'] if obj['total_net_value'] < 0 else 0 for obj in data])
+        }
+
+        summary['total_net'] = summary['total_positive'] + summary['total_negative']
+
+        return summary

--- a/jarbas/chamber_of_deputies/views.py
+++ b/jarbas/chamber_of_deputies/views.py
@@ -1,6 +1,7 @@
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 
 from jarbas.chamber_of_deputies.models import Reimbursement
+from jarbas.chamber_of_deputies.paginators import ReimbursementListPagination
 from jarbas.chamber_of_deputies.serializers import (ReimbursementSerializer,
                                                     ReceiptSerializer,
                                                     SameDayReimbursementSerializer,
@@ -12,6 +13,7 @@ class ReimbursementListView(ListAPIView):
 
     queryset = Reimbursement.objects.all()
     serializer_class = ReimbursementSerializer
+    pagination_class = ReimbursementListPagination
 
     def get(self, request):
 


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
This summary can help users to easily regard the total value spent with the filtered reimbursements.

**What was done to achieve this purpose?**
I modified the ReimbursementsListAPI paginator to include the summary of values.

In this case, however, I was unsure on how to deal with the negative reimbursement values that are on the database, since those can affect the total amount. To solve this, I simply generated two additional fields with the sum of positive and negative values.
