### PR TITLE
Remove streetView functionality

### DIFF
--- a/jarbas/layers/elm/Reimbursement/Company/View.elm
+++ b/jarbas/layers/elm/Reimbursement/Company/View.elm
@@ -14,66 +14,6 @@ import Reimbursement.Company.Model exposing (Activity, Company, Model)
 import Reimbursement.Company.Update exposing (Msg)
 
 
-{-| Generates a link to a Google Street View image:
-
-    streetImageUrl (Just "foobar") 42 3 "3.14" "1.99" 1
-    --> "https://maps.googleapis.com/maps/api/streetview?size=42x3&location=3.14%2C1.99&fov=90&heading=1&pitch=10&key=foobar"
-
-    streetImageUrl Nothing 42 3 "3.14" "1.99" 1
-    --> "https://maps.googleapis.com/maps/api/streetview?size=42x3&location=3.14%2C1.99&fov=90&heading=1&pitch=10&key="
-
--}
-streetImageUrl : Maybe String -> Int -> Int -> String -> String -> Int -> String
-streetImageUrl apiKey width height latitude longitude heading =
-    url
-        "https://maps.googleapis.com/maps/api/streetview"
-        [ ( "size", (toString width) ++ "x" ++ (toString height) )
-        , ( "location", latitude ++ "," ++ longitude )
-        , ( "fov", "90" )
-        , ( "heading", toString heading )
-        , ( "pitch", "10" )
-        , ( "key", Maybe.withDefault "" apiKey )
-        ]
-
-
-streetImageTag : Maybe String -> Maybe String -> Maybe String -> Int -> Html.Html Msg
-streetImageTag apiKey latitude longitude heading =
-    case latitude of
-        Just lat ->
-            case longitude of
-                Just long ->
-                    let
-                        source =
-                            streetImageUrl apiKey 640 400 lat long heading
-
-                        css =
-                            [ ( "width", "50%" )
-                            , ( "display", "inline-block" )
-                            , ( "margin", "1rem 0 0 0" )
-                            ]
-                    in
-                        a
-                            [ href source, target "_blank" ]
-                            [ img [ src source, style css ] [] ]
-
-                Nothing ->
-                    text ""
-
-        Nothing ->
-            text ""
-
-
-viewImage : Maybe String -> Company -> Html.Html Msg
-viewImage apiKey company =
-    let
-        images =
-            List.map
-                (streetImageTag apiKey company.latitude company.longitude)
-                [ 90, 180, 270, 360 ]
-    in
-        div [] images
-
-
 viewDate : Language -> Maybe Date.Date -> String
 viewDate lang maybeDate =
     case maybeDate of
@@ -151,7 +91,6 @@ viewCompany lang apiKey company =
                 [ icon
                 , text title
                 , location
-                , viewImage apiKey company
                 ]
             , Options.styled div [] (rows ++ activities)
             , Options.styled


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
Here we remove the street view functionality from Jarbas' reimbursements view. This is is the result of the following issue discussion https://github.com/okfn-brasil/serenata-de-amor/issues/441

**What was done to achieve this purpose?**
All the elm code related to rendering the four street view tiles are removed.

**How to test if it really works?**
Access a reimbursement that previously showed the street view tiles and check that it doesn't show anymore.


Here's how it looks like:
![Untitled drawing](https://user-images.githubusercontent.com/21130697/58671111-c1c65d80-8317-11e9-9e41-9e1a4d8bb727.png)
