### PR TITLE
Fix receipt url of reimbursements with electronic receipts

### DIFF
--- a/jarbas/chamber_of_deputies/models.py
+++ b/jarbas/chamber_of_deputies/models.py
@@ -31,11 +31,11 @@ class Receipt:
     @property
     def url(self):
         if self.document_type == self.ELETRONIC_RECEIPT_TYPE:
-            return self.eletronic_url()
+            return self.electronic_url()
 
         return self.pdf_url()
 
-    def eletronic_url(self):
+    def electronic_url(self):
         return (
             'https://www.camara.leg.br/cota-parlamentar/'
             'nota-fiscal-eletronica?ideDocumentoFiscal={}'
@@ -48,7 +48,6 @@ class Receipt:
             'http://www.camara.gov.br/'
             'cota-parlamentar/documentos/publ/{}/{}/{}.pdf'
         ).format(*args)
-
 
     @property
     def exists(self):

--- a/jarbas/chamber_of_deputies/models.py
+++ b/jarbas/chamber_of_deputies/models.py
@@ -20,19 +20,35 @@ class SocialMedia(models.Model):
 
 
 class Receipt:
+    ELETRONIC_RECEIPT_TYPE = 4
 
-    def __init__(self, year, applicant_id, document_id):
+    def __init__(self, year, applicant_id, document_id, document_type):
         self.year = year
         self.applicant_id = applicant_id
         self.document_id = document_id
+        self.document_type = document_type
 
     @property
     def url(self):
+        if self.document_type == self.ELETRONIC_RECEIPT_TYPE:
+            return self.eletronic_url()
+
+        return self.pdf_url()
+
+    def eletronic_url(self):
+        return (
+            'https://www.camara.leg.br/cota-parlamentar/'
+            'nota-fiscal-eletronica?ideDocumentoFiscal={}'
+        ).format(self.document_id)
+
+    def pdf_url(self):
         args = (self.applicant_id, self.year, self.document_id)
+
         return (
             'http://www.camara.gov.br/'
             'cota-parlamentar/documentos/publ/{}/{}/{}.pdf'
         ).format(*args)
+
 
     @property
     def exists(self):
@@ -107,7 +123,7 @@ class Reimbursement(models.Model):
         if self.receipt_fetched and not force:
             return None
 
-        receipt = Receipt(self.year, self.applicant_id, self.document_id)
+        receipt = Receipt(self.year, self.applicant_id, self.document_id, self.document_type)
         if receipt.exists:
             self.receipt_url = receipt.url
         self.receipt_fetched = True

--- a/jarbas/chamber_of_deputies/tests/test_receipt_class.py
+++ b/jarbas/chamber_of_deputies/tests/test_receipt_class.py
@@ -9,11 +9,17 @@ from jarbas.chamber_of_deputies.models import Receipt
 class TestReceipt(TestCase):
 
     def setUp(self):
-        self.receipt = Receipt(1970, 13, 42)
+        self.receipt = Receipt(1970, 13, 42, 1)
+        self.eletronic_receipt = Receipt(1970, 13, 42, 4)
 
     def test_url(self):
         expected = 'http://www.camara.gov.br/cota-parlamentar/documentos/publ/13/1970/42.pdf'
         self.assertEqual(expected, self.receipt.url)
+
+    def test_eletronic_url(self):
+        expected = ('https://www.camara.leg.br/cota-parlamentar/nota-fiscal-eletronica?'
+                    'ideDocumentoFiscal=42')
+        self.assertEqual(expected, self.eletronic_receipt.url)
 
     @patch('jarbas.chamber_of_deputies.models.head')
     def test_existing_url(self, mocked_head):

--- a/jarbas/chamber_of_deputies/tests/test_receipt_class.py
+++ b/jarbas/chamber_of_deputies/tests/test_receipt_class.py
@@ -10,16 +10,16 @@ class TestReceipt(TestCase):
 
     def setUp(self):
         self.receipt = Receipt(1970, 13, 42, 1)
-        self.eletronic_receipt = Receipt(1970, 13, 42, 4)
+        self.electronic_receipt = Receipt(1970, 13, 42, 4)
 
     def test_url(self):
         expected = 'http://www.camara.gov.br/cota-parlamentar/documentos/publ/13/1970/42.pdf'
         self.assertEqual(expected, self.receipt.url)
 
-    def test_eletronic_url(self):
+    def test_electronic_url(self):
         expected = ('https://www.camara.leg.br/cota-parlamentar/nota-fiscal-eletronica?'
                     'ideDocumentoFiscal=42')
-        self.assertEqual(expected, self.eletronic_receipt.url)
+        self.assertEqual(expected, self.electronic_receipt.url)
 
     @patch('jarbas.chamber_of_deputies.models.head')
     def test_existing_url(self, mocked_head):

--- a/jarbas/layers/elm/Internationalization.elm
+++ b/jarbas/layers/elm/Internationalization.elm
@@ -348,6 +348,9 @@ translate lang trans =
                         2 ->
                             DocumentType.expenseMadeAbroad
 
+                        4 ->
+                            DocumentType.electronicReceipt
+
                         _ ->
                             Common.empty
     in

--- a/jarbas/layers/elm/Internationalization/DocumentType.elm
+++ b/jarbas/layers/elm/Internationalization/DocumentType.elm
@@ -22,3 +22,9 @@ expenseMadeAbroad =
     TranslationSet
         "Expense made abroad"
         "Despesa no exterior"
+
+electronicReceipt : TranslationSet
+electronicReceipt =
+    TranslationSet
+        "Electronic receipt"
+        "Nota fiscal eletrônica"

--- a/jarbas/layers/elm/Reimbursement/Company/View.elm
+++ b/jarbas/layers/elm/Reimbursement/Company/View.elm
@@ -1,8 +1,7 @@
-module Reimbursement.Company.View exposing (streetImageUrl, view)
+module Reimbursement.Company.View exposing (view)
 
 import Date
 import Format.Date exposing (formatDate)
-import Format.Url exposing (url)
 import Html exposing (a, br, div, img, p, span, text)
 import Html.Attributes exposing (class, href, src, style, target)
 import Internationalization exposing (translate)


### PR DESCRIPTION
<!-- Thank you for contributing with us -->
<!-- This is just a template to help you make your point clear with this PR. :) --> 

**What is the purpose of this Pull Request?**
Fix the receipt URL of those reimbursements that the receipts are electronic

**What was done to achieve this purpose?**
The class `Receipt` was modified to build the `receipt_url` differently when the `document_type` indicates that it is of the electronic type (https://github.com/CamaraDosDeputados/dados-abertos/issues/268).

**How to test if it really works?**
You have to have in your database an existing Reimbursement with document_type = 4.
Or build one using this `document_id='6841408'` (Or any other `document_id` of a Reimbursement with electronic receipt - https://jarbas.serenata.ai/dashboard/chamber_of_deputies/reimbursement/?document_type=4) to be sure that it is a valid document_id with the right type and run:

```bash
docker-compose run --rm django python manage.py shell_plus
reimbursement = Reimbursement.objects.filter(document_type=4)[0]
reimbursement.receipt_url = None
reimbursement.get_receipt_url(force=True)
```
This will return a valid URL

**Who can help reviewing it?**
@cuducos @sergiomario 

**TODO**
After deploy, update the `receipt_url` and `receipt_fetched` of all reimbursements with `document_type` equals to `4`.

```bash
docker-compose run --rm django python manage.py shell_plus
Reimbursement.objects.filter(document_type=4).update(receipt_url=None, receipt_fetched=False)
quit()
docker-compose run --rm django python manage.py receipts
```
