### PR TITLE
Ensure company name is string in meal outlier classifier

### DIFF
--- a/rosie/rosie/chamber_of_deputies/classifiers/meal_price_outlier_classifier.py
+++ b/rosie/rosie/chamber_of_deputies/classifiers/meal_price_outlier_classifier.py
@@ -84,7 +84,7 @@ class MealPriceOutlierClassifier(TransformerMixin):
     def __applicable_rows(self, X):
         return (X['category'] == 'Meal') & \
             (X['recipient_id'].str.len() == 14) & \
-            (~X['recipient'].apply(self.__normalize_string).str.contains(self.HOTEL_REGEX))
+            (~X['recipient'].fillna('').apply(self.__normalize_string).str.contains(self.HOTEL_REGEX))
 
     def __applicable_company_rows(self, companies):
         return (companies['congresspeople'] > 3) & (companies['records'] > 20)

--- a/rosie/rosie/chamber_of_deputies/tests/fixtures/meal_price_outlier_classifier.csv
+++ b/rosie/rosie/chamber_of_deputies/tests/fixtures/meal_price_outlier_classifier.csv
@@ -80,3 +80,4 @@ applicant_id,category,recipient_id,recipient,net_value
 444,Meal,22472225000183,GOL,400
 444,Flight ticket issue,22472225000183,GOL,9999999
 444,Flight ticket issue,22472225000183,GOL,5
+444,Meal,11111111111111,,42


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

To address the bug discussed in #506 

**What was done to achieve this purpose?**

Before using a string method within the classifier, I used Pandas `fillna`  to replace `np.nan` (a _float_) by an empty string.

**How to test if it really works?**

I added an empty value as a feature, so `python rosie.py test chamber_of_deputies` is an option. But fully running Rosie with `python rosie.py run chamber_of_deputies` is also advised.

**Who can help reviewing it?**

@sergiomario @luizfzs