### PR TITLE
Add HTTPError handling when ReimbursementsURL doesn't exist

### DIFF
--- a/rosie/rosie/chamber_of_deputies/adapter.py
+++ b/rosie/rosie/chamber_of_deputies/adapter.py
@@ -6,6 +6,7 @@ from re import match
 
 import numpy as np
 import pandas as pd
+from urllib.error import HTTPError
 
 from serenata_toolbox.chamber_of_deputies.reimbursements import Reimbursements
 from serenata_toolbox.datasets import fetch
@@ -85,7 +86,10 @@ class Adapter:
 
         for year in years:
             self.log.info(f'Updating reimbursements from {year}')
-            Reimbursements(year, self.path)()
+            try:
+                Reimbursements(year, self.path)()
+            except HTTPError as e:
+                self.log.error(f'Could not update Reimbursement from year {year}: {e} - {e.filename}')
 
     def prepare_dataset(self, df):
         self.rename_categories(df)

--- a/rosie/rosie/chamber_of_deputies/adapter.py
+++ b/rosie/rosie/chamber_of_deputies/adapter.py
@@ -89,7 +89,7 @@ class Adapter:
             try:
                 Reimbursements(year, self.path)()
             except HTTPError as e:
-                self.log.error(f'Could not update Reimbursement from year {year}: {e} - {e.filename}')
+                self.log.error(f'Could not update Reimbursements from year {year}: {e} - {e.filename}')
 
     def prepare_dataset(self, df):
         self.rename_categories(df)


### PR DESCRIPTION
The issue happened when running Rosie on 2020-01-01. By the way the `adapter.py` works, it tries to fetch reimbursement files up to the year in which the application is running e.g. 2020. Since there is no such URL (at the time of this commit), the whole process fails due to an `HTTPError 404`. 

By adding this handling, the reimbursements that cannot be found are skipped from the download process and the application runs without any issues.

**What is the purpose of this Pull Request?**
The goal of this PR is to add error handling to `adapter.py` when attempting to obtain a reimbursement that doesn't exist on the Chamber of Deputies website. If someone runs Rosie today (at least by the time this PR has been created), they are going to get an error when trying to obtain the reimbursement file for the year 2020. This error causes Rosie to completely stop.

**What was done to achieve this purpose?**
To handle the error, a `try-except` block was added on the `update_reimbursements` method, targeting only `urllib.error.HTTPError` and logging it with an ERROR level.

**How to test if it really works?**
Today, the fix can be tested by simply running Rosie, since there is no reimbursement file for the year of 2020.
An alternative way is by advancing the computer time to an year that there are no reimbursement URL to fetch, then running Rosie. **Note that by doing this, you might get SSL errors due to the big gap between the clocks.**

You should see a message similar to this: 
> YYYY-01-01 13:36:41,512 - rosie.chamber_of_deputies.adapter - ERROR - Could not update Reimbursements from year YYYY: HTTP Error 404: Not Found - https://www.camara.leg.br/cotas/Ano-YYYY.csv.zip

**Who can help reviewing it?**
Anyone
