### PR TITLE
Adds a task to rebuild the search vector

### DIFF
--- a/contrib/update/update.yml
+++ b/contrib/update/update.yml
@@ -103,6 +103,13 @@
       environment:
         DATABASE_URL: "{{ lookup('env', 'DATABASE_URL') }}"
 
+    - name: run jarbas to rebuild the search vector
+      shell: python3 manage.py searchvector
+      args:
+        chdir: /opt/serenata-de-amor/
+      environment:
+        DATABASE_URL: "{{ lookup('env', 'DATABASE_URL') }}"
+
 - name: destroy instance
   hosts: 127.0.0.1
 


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

From times to times Jarbas is missing the search vector, i.e., when users try to search through the search bar, no results are returned.

**What was done to achieve this purpose?**

 I know there is a scheduled Celery task to rebuild the search vector from time to time (depending on environment configuration). I'm not sure if the production environment is using it or not. Either way, maybe having it as a fixed step in the update playbook might better address this issue.

**How to test if it really works?**

It's possible to tweak the playbook and run it locally to see if it works. Or brace yourselves and run it in production. The trick is to use a textual search (for example, an existing congresspeople name or a CNPJ) and expect to see results!