### PR TITLE
New branch default: main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://img.shields.io/travis/okfn-brasil/serenata-de-amor/master.svg)](https://travis-ci.org/okfn-brasil/serenata-de-amor)
+[![Build Status](https://img.shields.io/travis/okfn-brasil/serenata-de-amor/main.svg)](https://travis-ci.org/okfn-brasil/serenata-de-amor)
 [![Code Climate](https://img.shields.io/codeclimate/maintainability-percentage/okfn-brasil/serenata-de-amor.svg)](https://codeclimate.com/github/okfn-brasil/serenata-de-amor)
 [![Test Coverage](https://img.shields.io/codeclimate/coverage/okfn-brasil/serenata-de-amor.svg)](https://codeclimate.com/github/okfn-brasil/serenata-de-amor/test_coverage)
 [![Donate](https://img.shields.io/badge/donate-apoia.se-EB4A3B.svg)](https://apoia.se/serenata)

--- a/contrib/deploy.sh
+++ b/contrib/deploy.sh
@@ -1,6 +1,6 @@
 export CURRENT_DIR=$(pwd)
 cd /opt/serenata-de-amor
-git pull origin master
+git pull origin main
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml pull
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml stop
 docker-compose -f docker-compose.yml -f docker-compose.prod.yml run --rm django python manage.py collectstatic --no-input

--- a/jarbas/README.md
+++ b/jarbas/README.md
@@ -2,7 +2,7 @@
 
 [Jarbas](http://jarbas.serenata.ai/) is part of [Serenata de Amor](http://github.com/okfn-brasil/serenata-de-amor) — we fight corruption with data science.
 
-Jarbas is in charge of making data from [CEAP](https://github.com/okfn-brasil/serenata-de-amor/blob/master/CONTRIBUTING.md#more-about-the-quota-for-exercising-parliamentary-activity-ceap) more accessible. In the near future Jarbas will show what [Rosie](https://github.com/okfn-brasil/serenata-de-amor/tree/master/rosie) thinks of each reimbursement made for our congresspeople.
+Jarbas is in charge of making data from [CEAP](https://github.com/okfn-brasil/serenata-de-amor/blob/main/CONTRIBUTING.md#more-about-the-quota-for-exercising-parliamentary-activity-ceap) more accessible. In the near future Jarbas will show what [Rosie](https://github.com/okfn-brasil/serenata-de-amor/tree/main/rosie) thinks of each reimbursement made for our congresspeople.
 
 ## Table of Contents
 
@@ -228,8 +228,8 @@ $ docker-compose run --rm django python manage.py suspicions /mnt/data/suspicion
 $ docker-compose run --rm django python manage.py tweets
 ```
 
-If you're interesting in having a database full of data you can get the datasets running [Rosie](https://github.com/okfn-brasil/serenata-de-amor/tree/master/rosie).
-To add a fresh new `reimbursements.xz` or `suspicions.xz` brewed by [Rosie](https://github.com/okfn-brasil/serenata-de-amor/tree/master/rosie), or a `companies.xz` you've got from the [toolbox](https://github.com/okfn-brasil/serenata-toolbox), you just need copy these files to `contrib/data` and refer to them inside the container from the path `/mnt/data/`.
+If you're interesting in having a database full of data you can get the datasets running [Rosie](https://github.com/okfn-brasil/serenata-de-amor/tree/main/rosie).
+To add a fresh new `reimbursements.xz` or `suspicions.xz` brewed by [Rosie](https://github.com/okfn-brasil/serenata-de-amor/tree/main/rosie), or a `companies.xz` you've got from the [toolbox](https://github.com/okfn-brasil/serenata-toolbox), you just need copy these files to `contrib/data` and refer to them inside the container from the path `/mnt/data/`.
 
 #### Creating search vector
 
@@ -299,7 +299,7 @@ $ python manage.py companies <path to companies.xz>
 $ python manage.py tweets
 ```
 
-There are sample files to seed yout database inside `contrib/data/`. You can get full datasets running [Rosie](https://github.com/okfn-brasil/serenata-de-amor/tree/master/rosie) or directly with the [toolbox](https://github.com/okfn-brasil/serenata-toolbox).
+There are sample files to seed yout database inside `contrib/data/`. You can get full datasets running [Rosie](https://github.com/okfn-brasil/serenata-de-amor/tree/main/rosie) or directly with the [toolbox](https://github.com/okfn-brasil/serenata-toolbox).
 
 #### Creating search vector
 


### PR DESCRIPTION
**What is the purpose of this Pull Request?**
We made some changes to the repositories hosted on the Github platform. We changed the name of the default branch of our active repositories - which was previously “master” to “main”.

The change aims to review uses of language that can reinforce contexts of oppression. Although, in the scope of Github, the term master is not immediately associated with slavery, as in the case of the [Linux master/slaves analogy](https://www.theregister.com/2020/07/13/linux_adopts_inclusive_language/), its symbolic load is already sufficient to adopt a more neutral form.

**Who can help reviewing it?**
@cuducos 
